### PR TITLE
feat: control run and selectors via local flags

### DIFF
--- a/demo/src/app/domain/state/demo-local-state-interface.ts
+++ b/demo/src/app/domain/state/demo-local-state-interface.ts
@@ -3,4 +3,7 @@ import { Signal } from "@angular/core";
 export interface DemoLocalState {
   readonly isEnableComplete: Signal<boolean>;
   readonly isEnableCancel: Signal<boolean>;
+  readonly isEnableExecute: Signal<boolean>;
+  readonly isEnableSelectUser: Signal<boolean>;
+  readonly isEnableSelectWork: Signal<boolean>;
 }

--- a/demo/src/app/domain/state/local/demo-local-A.state.ts
+++ b/demo/src/app/domain/state/local/demo-local-A.state.ts
@@ -9,11 +9,23 @@ export class DemoLocalStateA implements DemoLocalState {
 
   private _isEnableComplete = computed(() => this.globalState.progress() >= 10);
   private _isEnableCancel   = computed(() => this.globalState.progress() < 10);
+  private _isEnableExecute  = computed(() => this.globalState.progress() < 10);
+  private _isEnableSelectUser = computed(() => false);
+  private _isEnableSelectWork = computed(() => false);
 
   get isEnableComplete(): Signal<boolean> {
     return this._isEnableComplete;
   }
   get isEnableCancel(): Signal<boolean> {
     return this._isEnableCancel;
+  }
+  get isEnableExecute(): Signal<boolean> {
+    return this._isEnableExecute;
+  }
+  get isEnableSelectUser(): Signal<boolean> {
+    return this._isEnableSelectUser;
+  }
+  get isEnableSelectWork(): Signal<boolean> {
+    return this._isEnableSelectWork;
   }
 }

--- a/demo/src/app/domain/state/local/demo-local-B.state.ts
+++ b/demo/src/app/domain/state/local/demo-local-B.state.ts
@@ -9,11 +9,23 @@ export class DemoLocalStateB implements DemoLocalState {
 
   private _isEnableComplete = computed(() => this.globalState.progress() >= 7);
   private _isEnableCancel   = computed(() => this.globalState.progress() < 7);
+  private _isEnableExecute  = computed(() => this.globalState.progress() < 7);
+  private _isEnableSelectUser = computed(() => false);
+  private _isEnableSelectWork = computed(() => false);
 
   get isEnableComplete(): Signal<boolean> {
     return this._isEnableComplete;
   }
   get isEnableCancel(): Signal<boolean> {
     return this._isEnableCancel;
+  }
+  get isEnableExecute(): Signal<boolean> {
+    return this._isEnableExecute;
+  }
+  get isEnableSelectUser(): Signal<boolean> {
+    return this._isEnableSelectUser;
+  }
+  get isEnableSelectWork(): Signal<boolean> {
+    return this._isEnableSelectWork;
   }
 }

--- a/demo/src/app/domain/state/local/demo-local-default.state.ts
+++ b/demo/src/app/domain/state/local/demo-local-default.state.ts
@@ -9,11 +9,23 @@ export class DemoLocalStateDefault implements DemoLocalState {
 
   private _isEnableComplete = signal(false);
   private _isEnableCancel   = signal(false);
+  private _isEnableExecute  = signal(false);
+  private _isEnableSelectUser = signal(true);
+  private _isEnableSelectWork = signal(true);
 
   get isEnableComplete(): Signal<boolean> {
     return this._isEnableComplete;
   }
   get isEnableCancel(): Signal<boolean> {
     return this._isEnableCancel;
+  }
+  get isEnableExecute(): Signal<boolean> {
+    return this._isEnableExecute;
+  }
+  get isEnableSelectUser(): Signal<boolean> {
+    return this._isEnableSelectUser;
+  }
+  get isEnableSelectWork(): Signal<boolean> {
+    return this._isEnableSelectWork;
   }
 }

--- a/demo/src/app/pages/demo-page/demo-page.ts
+++ b/demo/src/app/pages/demo-page/demo-page.ts
@@ -30,8 +30,11 @@ export class DemoPage {
     userName: signal('')
   };
   localState = {
-    isEnableComplete: signal(false),
-    isEnableCancel:  signal(false)
+    isEnableComplete:   signal(false),
+    isEnableCancel:     signal(false),
+    isEnableExecute:    signal(false),
+    isEnableSelectUser: signal(false),
+    isEnableSelectWork: signal(false)
   };
 
   // 「今のサービス」を保持する Signal。最初は undefined でOK。
@@ -52,8 +55,11 @@ export class DemoPage {
         if (!svc) return;
         this.globalState.workKind.set( svc.globalState.workKind() );
         this.globalState.userName .set( svc.globalState.userName() );
-        this.localState.isEnableComplete.set( svc.localState.isEnableComplete() );
-        this.localState.isEnableCancel .set( svc.localState.isEnableCancel() );
+        this.localState.isEnableComplete  .set( svc.localState.isEnableComplete() );
+        this.localState.isEnableCancel    .set( svc.localState.isEnableCancel() );
+        this.localState.isEnableExecute   .set( svc.localState.isEnableExecute() );
+        this.localState.isEnableSelectUser.set( svc.localState.isEnableSelectUser() );
+        this.localState.isEnableSelectWork.set( svc.localState.isEnableSelectWork() );
       });
     });
   }

--- a/demo/src/app/view/demo-view/demo-view.html
+++ b/demo/src/app/view/demo-view/demo-view.html
@@ -2,7 +2,7 @@
   <aside class="select-side">
     <div class="dropdown-group">
       <label class="dropdown-label" for="userSelect">ユーザー選択</label>
-      <select id="userSelect" [value]="globalState.userName()" (change)="onSelectUser($event)">
+      <select id="userSelect" [value]="globalState.userName()" (change)="onSelectUser($event)" [disabled]="!localState.isEnableSelectUser()">
         @for (user of userList; track user; let i = $index) {
           <option [value]="user">{{ user }}</option>
         }
@@ -10,7 +10,7 @@
     </div>
     <div class="dropdown-group">
       <label class="dropdown-label" for="workSelect">作業選択</label>
-      <select id="workSelect" [value]="globalState.workKind()" (change)="onSelectWork($event)">
+      <select id="workSelect" [value]="globalState.workKind()" (change)="onSelectWork($event)" [disabled]="!localState.isEnableSelectWork()">
         @for (work of workList; track work; let i = $index) {
           <option [value]="work">{{ work }}</option>
         }
@@ -37,8 +37,9 @@
       >
         キャンセル
       </button>
-      <button 
-        class="action-btn execute" 
+      <button
+        class="action-btn execute"
+        [disabled]="!localState.isEnableExecute()"
         (click)="onClickExecuteBtn()"
       >
         実行

--- a/demo/src/app/view/demo-view/demo-view.ts
+++ b/demo/src/app/view/demo-view/demo-view.ts
@@ -6,8 +6,23 @@ import { Component, computed, effect, EventEmitter, Input, Output, signal, Signa
   styleUrls: ['./demo-view.scss']
 })
 export class DemoView {
-  @Input() globalState!: { workKind: Signal<string>, userName: Signal<string> };
-  @Input() localState!: { isEnableComplete: Signal<boolean>, isEnableCancel: Signal<boolean> };
+  @Input() globalState: { workKind: Signal<string>; userName: Signal<string> } = {
+    workKind: signal(''),
+    userName: signal('')
+  };
+  @Input() localState: {
+    isEnableComplete: Signal<boolean>;
+    isEnableCancel: Signal<boolean>;
+    isEnableExecute: Signal<boolean>;
+    isEnableSelectUser: Signal<boolean>;
+    isEnableSelectWork: Signal<boolean>;
+  } = {
+    isEnableComplete: signal(false),
+    isEnableCancel: signal(false),
+    isEnableExecute: signal(false),
+    isEnableSelectUser: signal(false),
+    isEnableSelectWork: signal(false)
+  };
   @Input() userList: string[] = [];
   @Input() workList: string[] = [];
 


### PR DESCRIPTION
## Summary
- add execution and selector enable flags to local states
- drive DemoView button and selector disabled state via new signals
- propagate control flags through DemoPage

## Testing
- `npm run build`
- `CHROME_BIN=chromium-browser npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Cannot find the binary chromium-browser)*

------
https://chatgpt.com/codex/tasks/task_e_688e32eb3a748331a8d0b87772eefef9