### PR TITLE
Reset state on cancel

### DIFF
--- a/demo/src/app/domain/service/impl/demo-service-impl-A.service.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-A.service.ts
@@ -27,6 +27,9 @@ export class DemoServiceImplA implements DemoServiceInterface {
   }
 
   cancelWork(): void {
+    this.globalState.completeWork();
+    this.globalState.selectedUser('');
+    this.globalState.selectedWork('未確認');
     console.log('作業Aキャンセル');
   }
 

--- a/demo/src/app/domain/service/impl/demo-service-impl-B.service.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-B.service.ts
@@ -23,6 +23,9 @@ export class DemoServiceImplB implements DemoServiceInterface {
   }
 
   cancelWork(): void {
+    this.globalState.completeWork();
+    this.globalState.selectedUser('');
+    this.globalState.selectedWork('未確認');
     console.log('作業Bキャンセル');
   }
 

--- a/demo/src/app/domain/service/impl/demo-service-impl-default.service.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-default.service.ts
@@ -22,6 +22,9 @@ export class DemoServiceImplDefault implements DemoServiceInterface {
   }
 
   cancelWork(): void {
+    this.globalState.completeWork();
+    this.globalState.selectedUser('');
+    this.globalState.selectedWork('未確認');
     console.log('作業未選択のため何もしない。');
   }
 

--- a/demo/src/app/pages/demo-page/demo-page.ts
+++ b/demo/src/app/pages/demo-page/demo-page.ts
@@ -73,6 +73,7 @@ export class DemoPage {
 
   onCancel() {
     this.currentService()?.cancelWork();
+    this.currentService.set(this.serviceDefault);
   }
 
   onExecute() {


### PR DESCRIPTION
## Summary
- reset progress and clear selections when cancelling
- reset current service to default after cancelling

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_688ea6f2bd088331807d4fe9620aa1bd