### PR TITLE
feat: add task operation logging

### DIFF
--- a/demo/src/app/domain/service/impl/demo-service-impl-A.service.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-A.service.ts
@@ -17,9 +17,11 @@ export class DemoServiceImplA implements DemoServiceInterface {
   executeWork(): void {
     console.log('作業A実行');
     this.globalState.updateProgress();
+    this.globalState.addLog(this.globalState.workKind(), '実行', this.globalState.userName());
   }
 
   completeWork(): void {
+    this.globalState.addLog(this.globalState.workKind(), '完了', this.globalState.userName());
     this.globalState.completeWork();
     this.globalState.selectedUser('');
     this.globalState.selectedWork('未確認');
@@ -27,6 +29,7 @@ export class DemoServiceImplA implements DemoServiceInterface {
   }
 
   cancelWork(): void {
+    this.globalState.addLog(this.globalState.workKind(), 'キャンセル', this.globalState.userName());
     console.log('作業Aキャンセル');
   }
 
@@ -37,6 +40,7 @@ export class DemoServiceImplA implements DemoServiceInterface {
 
   selectWork(kind: string): void {
     this.globalState.selectedWork(kind);
+    this.globalState.addLog(kind, '選択', this.globalState.userName());
     console.log('作業変更:', kind);
   }
 }

--- a/demo/src/app/domain/service/impl/demo-service-impl-B.service.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-B.service.ts
@@ -13,9 +13,11 @@ export class DemoServiceImplB implements DemoServiceInterface {
   executeWork(): void {
     console.log('作業B実行');
     this.globalState.updateProgress();
+    this.globalState.addLog(this.globalState.workKind(), '実行', this.globalState.userName());
   }
 
   completeWork(): void {
+    this.globalState.addLog(this.globalState.workKind(), '完了', this.globalState.userName());
     this.globalState.completeWork();
     this.globalState.selectedUser('');
     this.globalState.selectedWork('未確認');
@@ -23,6 +25,7 @@ export class DemoServiceImplB implements DemoServiceInterface {
   }
 
   cancelWork(): void {
+    this.globalState.addLog(this.globalState.workKind(), 'キャンセル', this.globalState.userName());
     console.log('作業Bキャンセル');
   }
 
@@ -33,6 +36,7 @@ export class DemoServiceImplB implements DemoServiceInterface {
 
   selectWork(kind: string): void {
     this.globalState.selectedWork(kind);
+    this.globalState.addLog(kind, '選択', this.globalState.userName());
     console.log('作業変更:', kind);
   }
 }

--- a/demo/src/app/domain/service/impl/demo-service-impl-default.service.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-default.service.ts
@@ -11,10 +11,12 @@ export class DemoServiceImplDefault implements DemoServiceInterface {
   ) {}
 
   executeWork(): void {
+    this.globalState.addLog(this.globalState.workKind(), '実行', this.globalState.userName());
     console.log('作業未選択のため何もしない。');
   }
 
   completeWork(): void {
+    this.globalState.addLog(this.globalState.workKind(), '完了', this.globalState.userName());
     this.globalState.completeWork();
     this.globalState.selectedUser('');
     this.globalState.selectedWork('未確認');
@@ -22,6 +24,7 @@ export class DemoServiceImplDefault implements DemoServiceInterface {
   }
 
   cancelWork(): void {
+    this.globalState.addLog(this.globalState.workKind(), 'キャンセル', this.globalState.userName());
     console.log('作業未選択のため何もしない。');
   }
 
@@ -32,6 +35,7 @@ export class DemoServiceImplDefault implements DemoServiceInterface {
 
   selectWork(kind: string): void {
     this.globalState.selectedWork(kind);
+    this.globalState.addLog(kind, '選択', this.globalState.userName());
     console.log('作業' + kind + 'が選択されました。');
   }
 }

--- a/demo/src/app/domain/state/global/demo-global.state.ts
+++ b/demo/src/app/domain/state/global/demo-global.state.ts
@@ -1,10 +1,18 @@
 import { Injectable, signal, Signal } from '@angular/core';
 
+export interface DemoLog {
+  work: string;
+  action: string;
+  user: string;
+  timestamp: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class DemoState {
   private _workKind = signal('未確認');
   private _userName = signal('');
   private _progress = signal(0);
+  private _logs = signal<DemoLog[]>([]);
 
   get workKind(): Signal<string> {
     return this._workKind;
@@ -16,6 +24,10 @@ export class DemoState {
     return this._progress;
   }
 
+  get logs(): Signal<DemoLog[]> {
+    return this._logs;
+  }
+
   updateProgress() {
     const newProgress: number = this._progress() + 1;
     this._progress.set(newProgress);
@@ -23,6 +35,38 @@ export class DemoState {
 
   completeWork() {
     this._progress.set(0);
+  }
+
+  addLog(work: string, action: string, user: string) {
+    const entry: DemoLog = {
+      work,
+      action,
+      user,
+      timestamp: this.getTimestamp()
+    };
+    const newLogs = [...this._logs(), entry];
+    if (newLogs.length > 20) newLogs.shift();
+    this._logs.set(newLogs);
+  }
+
+  clearLog() {
+    this._logs.set([]);
+  }
+
+  deleteLog(index: number) {
+    const newLogs = [...this._logs()];
+    newLogs.splice(index, 1);
+    this._logs.set(newLogs);
+  }
+
+  private getTimestamp(): string {
+    const now = new Date();
+    const yyyy = now.getFullYear();
+    const mm = String(now.getMonth() + 1).padStart(2, '0');
+    const dd = String(now.getDate()).padStart(2, '0');
+    const hh = String(now.getHours()).padStart(2, '0');
+    const min = String(now.getMinutes()).padStart(2, '0');
+    return `${yyyy}/${mm}/${dd}/${hh}:${min}`;
   }
 
   // Setter相当のメソッドを用意

--- a/demo/src/app/view/demo-view/parts/demo-parts-log.html
+++ b/demo/src/app/view/demo-view/parts/demo-parts-log.html
@@ -4,14 +4,20 @@
     <thead>
       <tr>
         <th>#</th>
-        <th>内容</th>
+        <th>作業</th>
+        <th>処理</th>
+        <th>ユーザ</th>
+        <th>日時</th>
       </tr>
     </thead>
     <tbody>
-      @for (item of log(); track item; let i = $index) {
+      @for (item of log(); track $index; let i = $index) {
         <tr>
           <td>{{ i + 1 }}</td>
-          <td>{{ item }}</td>
+          <td>{{ item.work }}</td>
+          <td>{{ item.action }}</td>
+          <td>{{ item.user }}</td>
+          <td>{{ item.timestamp }}</td>
         </tr>
       }
     </tbody>

--- a/demo/src/app/view/demo-view/parts/demo-parts-log.ts
+++ b/demo/src/app/view/demo-view/parts/demo-parts-log.ts
@@ -1,4 +1,5 @@
-import { Component, signal } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { DemoState } from '../../../domain/state/global/demo-global.state';
 
 @Component({
   selector: 'app-demo-parts-log',
@@ -7,5 +8,6 @@ import { Component, signal } from '@angular/core';
   styleUrls: ['./demo-parts-log.scss']
 })
 export class DemoPartsLog {
-  log = signal<string[]>([]);
+  private demoState = inject(DemoState);
+  log = this.demoState.logs;
 }


### PR DESCRIPTION
## Summary
- add log storage and management in DemoState
- show log entries with work, action, user and timestamp
- record operations across task services

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ea8e6bdd883319796d3d1ab46c2cb