### PR TITLE
feat: enable scrolling log with newest first

### DIFF
--- a/demo/src/app/domain/state/global/demo-global.state.ts
+++ b/demo/src/app/domain/state/global/demo-global.state.ts
@@ -44,8 +44,8 @@ export class DemoState {
       user,
       timestamp: this.getTimestamp()
     };
-    const newLogs = [...this._logs(), entry];
-    if (newLogs.length > 20) newLogs.shift();
+    const newLogs = [entry, ...this._logs()];
+    if (newLogs.length > 20) newLogs.pop();
     this._logs.set(newLogs);
   }
 

--- a/demo/src/app/view/demo-view/parts/demo-parts-log.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-log.scss
@@ -9,7 +9,8 @@
   flex-direction: column;
   align-items: flex-start;
   height: 65vh;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .log-title {


### PR DESCRIPTION
## Summary
- allow log panel to scroll vertically when entries overflow
- show newest log entries first in the state

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688eaf74c614833181eb88028e192288