### PR TITLE
Limit log scrolling to table area

### DIFF
--- a/demo/src/app/view/demo-view/parts/demo-parts-log.html
+++ b/demo/src/app/view/demo-view/parts/demo-parts-log.html
@@ -1,25 +1,27 @@
 <aside class="log-side">
   <div class="log-title">変更履歴</div>
-  <table class="log-table">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>作業</th>
-        <th>処理</th>
-        <th>ユーザ</th>
-        <th>日時</th>
-      </tr>
-    </thead>
-    <tbody>
-      @for (item of log(); track $index; let i = $index) {
+  <div class="log-table-wrapper">
+    <table class="log-table">
+      <thead>
         <tr>
-          <td>{{ i + 1 }}</td>
-          <td>{{ item.work }}</td>
-          <td>{{ item.action }}</td>
-          <td>{{ item.user }}</td>
-          <td>{{ item.timestamp }}</td>
+          <th>#</th>
+          <th>作業</th>
+          <th>処理</th>
+          <th>ユーザ</th>
+          <th>日時</th>
         </tr>
-      }
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        @for (item of log(); track $index; let i = $index) {
+          <tr>
+            <td>{{ i + 1 }}</td>
+            <td>{{ item.work }}</td>
+            <td>{{ item.action }}</td>
+            <td>{{ item.user }}</td>
+            <td>{{ item.timestamp }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  </div>
 </aside>

--- a/demo/src/app/view/demo-view/parts/demo-parts-log.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-log.scss
@@ -9,8 +9,6 @@
   flex-direction: column;
   align-items: flex-start;
   height: 65vh;
-  overflow-x: hidden;
-  overflow-y: auto;
 }
 
 .log-title {
@@ -19,6 +17,13 @@
   color: #5d5d5d;
   margin-bottom: 1.1rem;
   letter-spacing: 0.01em;
+}
+
+.log-table-wrapper {
+  flex: 1 1 auto;
+  width: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .log-table {


### PR DESCRIPTION
## Summary
- wrap log table in dedicated scrollable div
- move overflow logic to new wrapper to keep sidebar header fixed

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_688eb155cc6c8331b473d26aee91f0b4