### PR TITLE
Fix demo container sizing to match viewport

### DIFF
--- a/demo/src/app/view/demo-view/demo-view.scss
+++ b/demo/src/app/view/demo-view/demo-view.scss
@@ -2,7 +2,8 @@
   display: flex;
   flex-direction: row;
   height: 100vh;
-  width: 100vw;
+  width: 100%;
+  box-sizing: border-box;
   justify-content: center;
   align-items: center;
   background: linear-gradient(110deg, #f7fafc 60%, #e3e9f3 100%);
@@ -15,7 +16,7 @@
     flex-direction: column;
     align-items: stretch;
     justify-content: flex-start;
-    min-height: 100vh;
+    height: 100vh;
     padding: 1rem;
   }
 }

--- a/demo/src/styles.scss
+++ b/demo/src/styles.scss
@@ -1,1 +1,8 @@
 /* You can add global styles to this file, and also import other style files */
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}


### PR DESCRIPTION
## Summary
- remove default body margins and hide overflow to stop unwanted scrolling
- ensure demo container uses full viewport width and accounts for padding

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688eb24f08c483318b40053a3617a76c