### PR TITLE
fix: keep log table header fixed

### DIFF
--- a/demo/src/app/view/demo-view/parts/demo-parts-log.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-log.scss
@@ -35,6 +35,12 @@
   overflow: hidden;
   box-shadow: 0 1px 7px 0 rgba(60,70,120,0.07);
 
+  thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+
   th, td {
     padding: 0.65rem 1.1rem;
     text-align: left;


### PR DESCRIPTION
## Summary
- keep log table header fixed while scrolling log entries

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688ebaeb10f88331972b0f84684ee7d2