### PR TITLE
Fix log table header staying sticky when scrolling

### DIFF
--- a/demo/src/app/view/demo-view/parts/demo-parts-log.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-log.scss
@@ -24,6 +24,8 @@
   width: 100%;
   overflow-y: auto;
   overflow-x: hidden;
+  border-radius: 1rem;
+  box-shadow: 0 1px 7px 0 rgba(60,70,120,0.07);
 }
 
 .log-table {
@@ -31,9 +33,6 @@
   border-collapse: separate;
   border-spacing: 0;
   background: #f7fafc;
-  border-radius: 1rem;
-  overflow: hidden;
-  box-shadow: 0 1px 7px 0 rgba(60,70,120,0.07);
 
   thead {
     position: sticky;


### PR DESCRIPTION
## Summary
- keep log header fixed by removing overflow clipping on table
- move rounded corner and shadow styling to the scroll wrapper

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_688ef8f6b1d08331823233128e399caa