### PR TITLE
feat: add placeholders for user and work selectors

### DIFF
--- a/demo/src/app/view/demo-view/parts/demo-parts-select.html
+++ b/demo/src/app/view/demo-view/parts/demo-parts-select.html
@@ -2,6 +2,7 @@
   <div class="dropdown-group">
     <label class="dropdown-label" for="userSelect">ユーザー選択</label>
     <select id="userSelect" [value]="globalState.userName()" (change)="onSelectUser($event)" [disabled]="!localState.isEnableSelectUser()">
+      <option value="" disabled>ユーザを選択。</option>
       @for (user of userList; track user; let i = $index) {
         <option [value]="user">{{ user }}</option>
       }
@@ -10,6 +11,7 @@
   <div class="dropdown-group">
     <label class="dropdown-label" for="workSelect">作業選択</label>
     <select id="workSelect" [value]="globalState.workKind()" (change)="onSelectWork($event)" [disabled]="!localState.isEnableSelectWork()">
+      <option value="" disabled>作業を選択。</option>
       @for (work of workList; track work; let i = $index) {
         <option [value]="work">{{ work }}</option>
       }


### PR DESCRIPTION
## Summary
- show `ユーザを選択。` in user dropdown when nothing is chosen
- show `作業を選択。` in work dropdown when nothing is chosen

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688efa83b3ec83318e84055281166ebc