### PR TITLE
fix: show placeholder for work selector

### DIFF
--- a/demo/src/app/view/demo-view/parts/demo-parts-select/demo-parts-select.html
+++ b/demo/src/app/view/demo-view/parts/demo-parts-select/demo-parts-select.html
@@ -1,7 +1,12 @@
 <aside class="select-side">
   <div class="dropdown-group">
     <label class="dropdown-label" for="userSelect">ユーザー選択</label>
-    <select id="userSelect" [value]="globalState.userName()" (change)="onSelectUser($event)" [disabled]="!localState.isEnableSelectUser()">
+    <select
+      id="userSelect"
+      [value]="globalState.userName()"
+      (change)="onSelectUser($event)"
+      [disabled]="!localState.isEnableSelectUser()"
+    >
       <option value="" disabled>ユーザを選択。</option>
       @for (user of userList; track user; let i = $index) {
         <option [value]="user">{{ user }}</option>
@@ -10,8 +15,13 @@
   </div>
   <div class="dropdown-group">
     <label class="dropdown-label" for="workSelect">作業選択</label>
-    <select id="workSelect" [value]="globalState.workKind()" (change)="onSelectWork($event)" [disabled]="!localState.isEnableSelectWork()">
-      <option value="" disabled>作業を選択。</option>
+    <select
+      id="workSelect"
+      [value]="globalState.workKind()"
+      (change)="onSelectWork($event)"
+      [disabled]="!localState.isEnableSelectWork()"
+    >
+      <option value="未確認" disabled>作業を選択。</option>
       @for (work of workList; track work; let i = $index) {
         <option [value]="work">{{ work }}</option>
       }


### PR DESCRIPTION
## Summary
- align work selector placeholder with default state so the initial display shows "作業を選択。"

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_688f144f4e4c8331a8697a1405c8effb