### PR TITLE
fix: display Work C dialog using built-in control flow

### DIFF
--- a/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.html
+++ b/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.html
@@ -29,20 +29,22 @@
     </button>
   </div>
 
-  <div class="dialog-overlay" *ngIf="localState.isVisibleDialog()">
-    <div class="dialog">
-      <div class="dialog-content">
-        <span>作業数：</span>
-        <div class="count-box">
-          <button (click)="onClickPlusBtn()" [disabled]="localState.isDisablePlus()">+</button>
-          <div class="count-display">{{ workCount }}</div>
-          <button (click)="onClickMinusBtn()" [disabled]="localState.isDisableMinus()">-</button>
+  @if (localState.isVisibleDialog()) {
+    <div class="dialog-overlay">
+      <div class="dialog">
+        <div class="dialog-content">
+          <span>作業数：</span>
+          <div class="count-box">
+            <button (click)="onClickPlusBtn()" [disabled]="localState.isDisablePlus()">+</button>
+            <div class="count-display">{{ workCount }}</div>
+            <button (click)="onClickMinusBtn()" [disabled]="localState.isDisableMinus()">-</button>
+          </div>
+        </div>
+        <div class="dialog-actions">
+          <button (click)="onClickDecideBtn()" [disabled]="localState.isDisableDecide()">決定</button>
+          <button (click)="onClickBackBtn()" [disabled]="localState.isDisableBack()">戻る</button>
         </div>
       </div>
-      <div class="dialog-actions">
-        <button (click)="onClickDecideBtn()" [disabled]="localState.isDisableDecide()">決定</button>
-        <button (click)="onClickBackBtn()" [disabled]="localState.isDisableBack()">戻る</button>
-      </div>
     </div>
-  </div>
+  }
 </div>


### PR DESCRIPTION
## Summary
- use Angular's `@if` control flow instead of deprecated `*ngIf`
- ensure dialog for Work C toggles as expected

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_688f1437e40c8331954ec7e34f605da4