### PR TITLE
refactor: rename disabled flags to isEnable

### DIFF
--- a/demo/src/app/domain/state/demo-local-state-interface.ts
+++ b/demo/src/app/domain/state/demo-local-state-interface.ts
@@ -7,8 +7,8 @@ export interface DemoLocalState {
   readonly isEnableSelectUser: Signal<boolean>;
   readonly isEnableSelectWork: Signal<boolean>;
   readonly isVisibleDialog: Signal<boolean>;
-  readonly isDisablePlus: Signal<boolean>;
-  readonly isDisableMinus: Signal<boolean>;
-  readonly isDisableDecide: Signal<boolean>;
-  readonly isDisableBack: Signal<boolean>;
+  readonly isEnablePlus: Signal<boolean>;
+  readonly isEnableMinus: Signal<boolean>;
+  readonly isEnableDecide: Signal<boolean>;
+  readonly isEnableBack: Signal<boolean>;
 }

--- a/demo/src/app/domain/state/local/demo-local-A.state.ts
+++ b/demo/src/app/domain/state/local/demo-local-A.state.ts
@@ -13,10 +13,10 @@ export class DemoLocalStateA implements DemoLocalState {
   private _isEnableSelectUser = computed(() => false);
   private _isEnableSelectWork = computed(() => false);
   private _isVisibleDialog = signal(false);
-  private _isDisablePlus   = signal(false);
-  private _isDisableMinus  = signal(false);
-  private _isDisableDecide = signal(false);
-  private _isDisableBack   = signal(false);
+  private _isEnablePlus   = signal(true);
+  private _isEnableMinus  = signal(true);
+  private _isEnableDecide = signal(true);
+  private _isEnableBack   = signal(true);
 
   get isEnableComplete(): Signal<boolean> {
     return this._isEnableComplete;
@@ -36,16 +36,16 @@ export class DemoLocalStateA implements DemoLocalState {
   get isVisibleDialog(): Signal<boolean> {
     return this._isVisibleDialog;
   }
-  get isDisablePlus(): Signal<boolean> {
-    return this._isDisablePlus;
+  get isEnablePlus(): Signal<boolean> {
+    return this._isEnablePlus;
   }
-  get isDisableMinus(): Signal<boolean> {
-    return this._isDisableMinus;
+  get isEnableMinus(): Signal<boolean> {
+    return this._isEnableMinus;
   }
-  get isDisableDecide(): Signal<boolean> {
-    return this._isDisableDecide;
+  get isEnableDecide(): Signal<boolean> {
+    return this._isEnableDecide;
   }
-  get isDisableBack(): Signal<boolean> {
-    return this._isDisableBack;
+  get isEnableBack(): Signal<boolean> {
+    return this._isEnableBack;
   }
 }

--- a/demo/src/app/domain/state/local/demo-local-B.state.ts
+++ b/demo/src/app/domain/state/local/demo-local-B.state.ts
@@ -13,10 +13,10 @@ export class DemoLocalStateB implements DemoLocalState {
   private _isEnableSelectUser = computed(() => false);
   private _isEnableSelectWork = computed(() => false);
   private _isVisibleDialog = signal(false);
-  private _isDisablePlus   = signal(false);
-  private _isDisableMinus  = signal(false);
-  private _isDisableDecide = signal(false);
-  private _isDisableBack   = signal(false);
+  private _isEnablePlus   = signal(true);
+  private _isEnableMinus  = signal(true);
+  private _isEnableDecide = signal(true);
+  private _isEnableBack   = signal(true);
 
   get isEnableComplete(): Signal<boolean> {
     return this._isEnableComplete;
@@ -36,16 +36,16 @@ export class DemoLocalStateB implements DemoLocalState {
   get isVisibleDialog(): Signal<boolean> {
     return this._isVisibleDialog;
   }
-  get isDisablePlus(): Signal<boolean> {
-    return this._isDisablePlus;
+  get isEnablePlus(): Signal<boolean> {
+    return this._isEnablePlus;
   }
-  get isDisableMinus(): Signal<boolean> {
-    return this._isDisableMinus;
+  get isEnableMinus(): Signal<boolean> {
+    return this._isEnableMinus;
   }
-  get isDisableDecide(): Signal<boolean> {
-    return this._isDisableDecide;
+  get isEnableDecide(): Signal<boolean> {
+    return this._isEnableDecide;
   }
-  get isDisableBack(): Signal<boolean> {
-    return this._isDisableBack;
+  get isEnableBack(): Signal<boolean> {
+    return this._isEnableBack;
   }
 }

--- a/demo/src/app/domain/state/local/demo-local-C.state.ts
+++ b/demo/src/app/domain/state/local/demo-local-C.state.ts
@@ -13,10 +13,10 @@ export class DemoLocalStateC implements DemoLocalState {
   private _isEnableSelectWork = computed(() => false);
 
   private _isVisibleDialog = signal(false);
-  private _isDisablePlus   = signal(false);
-  private _isDisableMinus  = signal(false);
-  private _isDisableDecide = signal(false);
-  private _isDisableBack   = signal(false);
+  private _isEnablePlus   = signal(true);
+  private _isEnableMinus  = signal(true);
+  private _isEnableDecide = signal(true);
+  private _isEnableBack   = signal(true);
 
   get isEnableComplete(): Signal<boolean> { return this._isEnableComplete; }
   get isEnableCancel(): Signal<boolean> { return this._isEnableCancel; }
@@ -24,10 +24,10 @@ export class DemoLocalStateC implements DemoLocalState {
   get isEnableSelectUser(): Signal<boolean> { return this._isEnableSelectUser; }
   get isEnableSelectWork(): Signal<boolean> { return this._isEnableSelectWork; }
   get isVisibleDialog(): Signal<boolean> { return this._isVisibleDialog; }
-  get isDisablePlus(): Signal<boolean> { return this._isDisablePlus; }
-  get isDisableMinus(): Signal<boolean> { return this._isDisableMinus; }
-  get isDisableDecide(): Signal<boolean> { return this._isDisableDecide; }
-  get isDisableBack(): Signal<boolean> { return this._isDisableBack; }
+  get isEnablePlus(): Signal<boolean> { return this._isEnablePlus; }
+  get isEnableMinus(): Signal<boolean> { return this._isEnableMinus; }
+  get isEnableDecide(): Signal<boolean> { return this._isEnableDecide; }
+  get isEnableBack(): Signal<boolean> { return this._isEnableBack; }
 
   setDialogVisible(flag: boolean) {
     this._isVisibleDialog.set(flag);

--- a/demo/src/app/domain/state/local/demo-local-default.state.ts
+++ b/demo/src/app/domain/state/local/demo-local-default.state.ts
@@ -13,10 +13,10 @@ export class DemoLocalStateDefault implements DemoLocalState {
   private _isEnableSelectUser = signal(true);
   private _isEnableSelectWork = signal(true);
   private _isVisibleDialog = signal(false);
-  private _isDisablePlus   = signal(false);
-  private _isDisableMinus  = signal(false);
-  private _isDisableDecide = signal(false);
-  private _isDisableBack   = signal(false);
+  private _isEnablePlus   = signal(true);
+  private _isEnableMinus  = signal(true);
+  private _isEnableDecide = signal(true);
+  private _isEnableBack   = signal(true);
 
   get isEnableComplete(): Signal<boolean> {
     return this._isEnableComplete;
@@ -36,16 +36,16 @@ export class DemoLocalStateDefault implements DemoLocalState {
   get isVisibleDialog(): Signal<boolean> {
     return this._isVisibleDialog;
   }
-  get isDisablePlus(): Signal<boolean> {
-    return this._isDisablePlus;
+  get isEnablePlus(): Signal<boolean> {
+    return this._isEnablePlus;
   }
-  get isDisableMinus(): Signal<boolean> {
-    return this._isDisableMinus;
+  get isEnableMinus(): Signal<boolean> {
+    return this._isEnableMinus;
   }
-  get isDisableDecide(): Signal<boolean> {
-    return this._isDisableDecide;
+  get isEnableDecide(): Signal<boolean> {
+    return this._isEnableDecide;
   }
-  get isDisableBack(): Signal<boolean> {
-    return this._isDisableBack;
+  get isEnableBack(): Signal<boolean> {
+    return this._isEnableBack;
   }
 }

--- a/demo/src/app/pages/demo-page/demo-page.ts
+++ b/demo/src/app/pages/demo-page/demo-page.ts
@@ -38,10 +38,10 @@ export class DemoPage {
     isEnableSelectUser: signal(false),
     isEnableSelectWork: signal(false),
     isVisibleDialog:    signal(false),
-    isDisablePlus:      signal(false),
-    isDisableMinus:     signal(false),
-    isDisableDecide:    signal(false),
-    isDisableBack:      signal(false)
+    isEnablePlus:      signal(true),
+    isEnableMinus:     signal(true),
+    isEnableDecide:    signal(true),
+    isEnableBack:      signal(true)
   };
 
   // 「今のサービス」を保持する Signal。最初は undefined でOK。
@@ -70,10 +70,10 @@ export class DemoPage {
         this.localState.isEnableSelectUser.set( svc.localState.isEnableSelectUser() );
         this.localState.isEnableSelectWork.set( svc.localState.isEnableSelectWork() );
         this.localState.isVisibleDialog   .set( svc.localState.isVisibleDialog() );
-        this.localState.isDisablePlus     .set( svc.localState.isDisablePlus() );
-        this.localState.isDisableMinus    .set( svc.localState.isDisableMinus() );
-        this.localState.isDisableDecide   .set( svc.localState.isDisableDecide() );
-        this.localState.isDisableBack     .set( svc.localState.isDisableBack() );
+        this.localState.isEnablePlus     .set( svc.localState.isEnablePlus() );
+        this.localState.isEnableMinus    .set( svc.localState.isEnableMinus() );
+        this.localState.isEnableDecide   .set( svc.localState.isEnableDecide() );
+        this.localState.isEnableBack     .set( svc.localState.isEnableBack() );
       });
     });
   }

--- a/demo/src/app/view/demo-view/demo-view.ts
+++ b/demo/src/app/view/demo-view/demo-view.ts
@@ -27,10 +27,10 @@ export class DemoView {
     isEnableSelectUser: Signal<boolean>;
     isEnableSelectWork: Signal<boolean>;
     isVisibleDialog: Signal<boolean>;
-    isDisablePlus: Signal<boolean>;
-    isDisableMinus: Signal<boolean>;
-    isDisableDecide: Signal<boolean>;
-    isDisableBack: Signal<boolean>;
+    isEnablePlus: Signal<boolean>;
+    isEnableMinus: Signal<boolean>;
+    isEnableDecide: Signal<boolean>;
+    isEnableBack: Signal<boolean>;
   } = {
     isEnableComplete: signal(false),
     isEnableCancel: signal(false),
@@ -38,10 +38,10 @@ export class DemoView {
     isEnableSelectUser: signal(false),
     isEnableSelectWork: signal(false),
     isVisibleDialog: signal(false),
-    isDisablePlus: signal(false),
-    isDisableMinus: signal(false),
-    isDisableDecide: signal(false),
-    isDisableBack: signal(false)
+    isEnablePlus: signal(true),
+    isEnableMinus: signal(true),
+    isEnableDecide: signal(true),
+    isEnableBack: signal(true)
   };
   @Input() userList: string[] = [];
   @Input() workList: string[] = [];

--- a/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.html
+++ b/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.html
@@ -35,14 +35,14 @@
         <div class="dialog-content">
           <span>作業数：</span>
           <div class="count-box">
-            <button (click)="onClickPlusBtn()" [disabled]="localState.isDisablePlus()">+</button>
+            <button (click)="onClickPlusBtn()" [disabled]="!localState.isEnablePlus()">+</button>
             <div class="count-display">{{ workCount }}</div>
-            <button (click)="onClickMinusBtn()" [disabled]="localState.isDisableMinus()">-</button>
+            <button (click)="onClickMinusBtn()" [disabled]="!localState.isEnableMinus()">-</button>
           </div>
         </div>
         <div class="dialog-actions">
-          <button (click)="onClickDecideBtn()" [disabled]="localState.isDisableDecide()">決定</button>
-          <button (click)="onClickBackBtn()" [disabled]="localState.isDisableBack()">戻る</button>
+          <button (click)="onClickDecideBtn()" [disabled]="!localState.isEnableDecide()">決定</button>
+          <button (click)="onClickBackBtn()" [disabled]="!localState.isEnableBack()">戻る</button>
         </div>
       </div>
     </div>

--- a/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.ts
+++ b/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.ts
@@ -16,19 +16,19 @@ export class DemoPartsCenter {
     isEnableCancel: Signal<boolean>;
     isEnableExecute: Signal<boolean>;
     isVisibleDialog: Signal<boolean>;
-    isDisablePlus: Signal<boolean>;
-    isDisableMinus: Signal<boolean>;
-    isDisableDecide: Signal<boolean>;
-    isDisableBack: Signal<boolean>;
+    isEnablePlus: Signal<boolean>;
+    isEnableMinus: Signal<boolean>;
+    isEnableDecide: Signal<boolean>;
+    isEnableBack: Signal<boolean>;
   } = {
     isEnableComplete: signal(false),
     isEnableCancel: signal(false),
     isEnableExecute: signal(false),
     isVisibleDialog: signal(false),
-    isDisablePlus: signal(false),
-    isDisableMinus: signal(false),
-    isDisableDecide: signal(false),
-    isDisableBack: signal(false)
+    isEnablePlus: signal(true),
+    isEnableMinus: signal(true),
+    isEnableDecide: signal(true),
+    isEnableBack: signal(true)
   };
 
   @Output() click_complete_event = new EventEmitter<void>();


### PR DESCRIPTION
## Summary
- replace negative isDisable* flags with positive isEnable* signals
- invert disabled bindings to use negated isEnable values in templates

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f248071088331957d9ce42b3392b1