### PR TITLE
fix: require user before switching work

### DIFF
--- a/demo/src/app/pages/demo-page/demo-page.ts
+++ b/demo/src/app/pages/demo-page/demo-page.ts
@@ -101,11 +101,34 @@ export class DemoPage {
   }
 
   onSelectUser(user: string) {
-    this.currentService()?.selectUser(user);
+    const svc = this.currentService();
+    svc?.selectUser(user);
+
+    const work = svc?.globalState.workKind();
+    if (!work || work === '未確認') return;
+
+    const next = work === '作業A'
+      ? this.serviceA
+      : work === '作業B'
+        ? this.serviceB
+        : work === '作業C'
+          ? this.serviceC
+          : this.serviceDefault;
+
+    if (next !== this.currentService()) {
+      this.currentService.set(next);
+      next.selectWork(work);
+    }
   }
 
   onSelectWork(work: string) {
-    // サービス切替
+    const svc = this.currentService();
+    const user = svc?.globalState.userName();
+    if (!user) {
+      svc?.selectWork(work);
+      return;
+    }
+
     const next = work === '作業A'
       ? this.serviceA
       : work === '作業B'


### PR DESCRIPTION
## Summary
- avoid switching work when user not selected
- switch work service when both user and work are chosen

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688f2502687883319dd1c562b94e9bd1