### PR TITLE
refactor: extract dialog to component

### DIFF
--- a/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.html
+++ b/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.html
@@ -30,21 +30,10 @@
   </div>
 
   @if (localState.isVisibleDialog()) {
-    <div class="dialog-overlay">
-      <div class="dialog">
-        <div class="dialog-content">
-          <span>作業数：</span>
-          <div class="count-box">
-            <button (click)="onClickPlusBtn()" [disabled]="!localState.isEnablePlus()">+</button>
-            <div class="count-display">{{ workCount }}</div>
-            <button (click)="onClickMinusBtn()" [disabled]="!localState.isEnableMinus()">-</button>
-          </div>
-        </div>
-        <div class="dialog-actions">
-          <button (click)="onClickDecideBtn()" [disabled]="!localState.isEnableDecide()">決定</button>
-          <button (click)="onClickBackBtn()" [disabled]="!localState.isEnableBack()">戻る</button>
-        </div>
-      </div>
-    </div>
+    <app-demo-parts-dialog
+      [localState]="localState"
+      (click_decide_event)="click_decide_event.emit($event)"
+      (click_back_event)="click_back_event.emit()"
+    />
   }
 </div>

--- a/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.scss
@@ -58,35 +58,3 @@
     margin-bottom: 2rem;
   }
 }
-
-.dialog-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0, 0, 0, 0.3);
-}
-
-.dialog {
-  background: #fff;
-  padding: 1rem;
-  border-radius: 0.5rem;
-}
-
-.count-box {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin-left: 0.5rem;
-}
-
-.dialog-actions {
-  margin-top: 1rem;
-  display: flex;
-  justify-content: flex-end;
-  gap: 1rem;
-}

--- a/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.ts
+++ b/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.ts
@@ -1,10 +1,12 @@
 import { Component, EventEmitter, Input, Output, Signal, computed, signal } from '@angular/core';
+import { DemoPartsDialog } from '../demo-parts-dialog/demo-parts-dialog';
 
 @Component({
   selector: 'app-demo-parts-center',
   standalone: true,
   templateUrl: './demo-parts-center.html',
-  styleUrls: ['./demo-parts-center.scss']
+  styleUrls: ['./demo-parts-center.scss'],
+  imports: [DemoPartsDialog]
 })
 export class DemoPartsCenter {
   @Input() globalState: { workKind: Signal<string>; progress: Signal<number> } = {
@@ -45,8 +47,6 @@ export class DemoPartsCenter {
     `完了数：${this.globalState?.progress()}`
   );
 
-  workCount = 1;
-
   onClickCompleteBtn() {
     this.click_complete_event.emit();
   }
@@ -57,23 +57,5 @@ export class DemoPartsCenter {
 
   onClickExecuteBtn() {
     this.click_execute_event.emit();
-  }
-
-  onClickPlusBtn() {
-    this.workCount++;
-  }
-
-  onClickMinusBtn() {
-    if (this.workCount > 1) this.workCount--;
-  }
-
-  onClickDecideBtn() {
-    this.click_decide_event.emit(this.workCount);
-    this.workCount = 1;
-  }
-
-  onClickBackBtn() {
-    this.click_back_event.emit();
-    this.workCount = 1;
   }
 }

--- a/demo/src/app/view/demo-view/parts/demo-parts-dialog/demo-parts-dialog.html
+++ b/demo/src/app/view/demo-view/parts/demo-parts-dialog/demo-parts-dialog.html
@@ -1,0 +1,16 @@
+<div class="dialog-overlay">
+  <div class="dialog">
+    <div class="dialog-content">
+      <span>作業数：</span>
+      <div class="count-box">
+        <button (click)="onClickPlusBtn()" [disabled]="!localState.isEnablePlus()">+</button>
+        <div class="count-display">{{ workCount }}</div>
+        <button (click)="onClickMinusBtn()" [disabled]="!localState.isEnableMinus()">-</button>
+      </div>
+    </div>
+    <div class="dialog-actions">
+      <button (click)="onClickDecideBtn()" [disabled]="!localState.isEnableDecide()">決定</button>
+      <button (click)="onClickBackBtn()" [disabled]="!localState.isEnableBack()">戻る</button>
+    </div>
+  </div>
+</div>

--- a/demo/src/app/view/demo-view/parts/demo-parts-dialog/demo-parts-dialog.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-dialog/demo-parts-dialog.scss
@@ -1,0 +1,31 @@
+.dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.3);
+}
+
+.dialog {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 0.5rem;
+}
+
+.count-box {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-left: 0.5rem;
+}
+
+.dialog-actions {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}

--- a/demo/src/app/view/demo-view/parts/demo-parts-dialog/demo-parts-dialog.ts
+++ b/demo/src/app/view/demo-view/parts/demo-parts-dialog/demo-parts-dialog.ts
@@ -1,0 +1,44 @@
+import { Component, EventEmitter, Input, Output, Signal, signal } from '@angular/core';
+
+@Component({
+  selector: 'app-demo-parts-dialog',
+  standalone: true,
+  templateUrl: './demo-parts-dialog.html',
+  styleUrls: ['./demo-parts-dialog.scss']
+})
+export class DemoPartsDialog {
+  @Input() localState: {
+    isEnablePlus: Signal<boolean>;
+    isEnableMinus: Signal<boolean>;
+    isEnableDecide: Signal<boolean>;
+    isEnableBack: Signal<boolean>;
+  } = {
+    isEnablePlus: signal(true),
+    isEnableMinus: signal(true),
+    isEnableDecide: signal(true),
+    isEnableBack: signal(true)
+  };
+
+  @Output() click_decide_event = new EventEmitter<number>();
+  @Output() click_back_event = new EventEmitter<void>();
+
+  workCount = 1;
+
+  onClickPlusBtn() {
+    this.workCount++;
+  }
+
+  onClickMinusBtn() {
+    if (this.workCount > 1) this.workCount--;
+  }
+
+  onClickDecideBtn() {
+    this.click_decide_event.emit(this.workCount);
+    this.workCount = 1;
+  }
+
+  onClickBackBtn() {
+    this.click_back_event.emit();
+    this.workCount = 1;
+  }
+}


### PR DESCRIPTION
## Summary
- create standalone `DemoPartsDialog` and move dialog markup/logic out of `DemoPartsCenter`
- use `DemoPartsDialog` inside center and clean up dialog styles

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_688f2cfa17c4833199786353db375b15