### PR TITLE
refactor: move dialog to demo view

### DIFF
--- a/demo/src/app/view/demo-view/demo-view.html
+++ b/demo/src/app/view/demo-view/demo-view.html
@@ -14,9 +14,15 @@
     (click_complete_event)="click_complete_event.emit()"
     (click_cancel_event)="click_cancel_event.emit()"
     (click_execute_event)="click_execute_event.emit()"
-    (click_decide_event)="click_decide_event.emit($event)"
-    (click_back_event)="click_back_event.emit()"
   ></app-demo-parts-center>
 
   <app-demo-parts-log></app-demo-parts-log>
+
+  @if (localState.isVisibleDialog()) {
+    <app-demo-parts-dialog
+      [localState]="localState"
+      (click_decide_event)="click_decide_event.emit($event)"
+      (click_back_event)="click_back_event.emit()"
+    />
+  }
 </div>

--- a/demo/src/app/view/demo-view/demo-view.ts
+++ b/demo/src/app/view/demo-view/demo-view.ts
@@ -2,11 +2,12 @@ import { Component, EventEmitter, Input, Output, Signal, signal } from '@angular
 import { DemoPartsSelect } from './parts/demo-parts-select/demo-parts-select';
 import { DemoPartsCenter } from './parts/demo-parts-center/demo-parts-center';
 import { DemoPartsLog } from './parts/demo-parts-log/demo-parts-log';
+import { DemoPartsDialog } from './parts/demo-parts-dialog/demo-parts-dialog';
 
 @Component({
   selector: 'app-demo-view',
   standalone: true,
-  imports: [DemoPartsSelect, DemoPartsCenter, DemoPartsLog],
+  imports: [DemoPartsSelect, DemoPartsCenter, DemoPartsLog, DemoPartsDialog],
   templateUrl: './demo-view.html',
   styleUrls: ['./demo-view.scss']
 })

--- a/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.html
+++ b/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.html
@@ -28,12 +28,4 @@
       実行
     </button>
   </div>
-
-  @if (localState.isVisibleDialog()) {
-    <app-demo-parts-dialog
-      [localState]="localState"
-      (click_decide_event)="click_decide_event.emit($event)"
-      (click_back_event)="click_back_event.emit()"
-    />
-  }
 </div>

--- a/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.ts
+++ b/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.ts
@@ -1,12 +1,10 @@
 import { Component, EventEmitter, Input, Output, Signal, computed, signal } from '@angular/core';
-import { DemoPartsDialog } from '../demo-parts-dialog/demo-parts-dialog';
 
 @Component({
   selector: 'app-demo-parts-center',
   standalone: true,
   templateUrl: './demo-parts-center.html',
-  styleUrls: ['./demo-parts-center.scss'],
-  imports: [DemoPartsDialog]
+  styleUrls: ['./demo-parts-center.scss']
 })
 export class DemoPartsCenter {
   @Input() globalState: { workKind: Signal<string>; progress: Signal<number> } = {
@@ -17,27 +15,15 @@ export class DemoPartsCenter {
     isEnableComplete: Signal<boolean>;
     isEnableCancel: Signal<boolean>;
     isEnableExecute: Signal<boolean>;
-    isVisibleDialog: Signal<boolean>;
-    isEnablePlus: Signal<boolean>;
-    isEnableMinus: Signal<boolean>;
-    isEnableDecide: Signal<boolean>;
-    isEnableBack: Signal<boolean>;
   } = {
     isEnableComplete: signal(false),
     isEnableCancel: signal(false),
-    isEnableExecute: signal(false),
-    isVisibleDialog: signal(false),
-    isEnablePlus: signal(true),
-    isEnableMinus: signal(true),
-    isEnableDecide: signal(true),
-    isEnableBack: signal(true)
+    isEnableExecute: signal(false)
   };
 
   @Output() click_complete_event = new EventEmitter<void>();
   @Output() click_cancel_event   = new EventEmitter<void>();
   @Output() click_execute_event  = new EventEmitter<void>();
-  @Output() click_decide_event   = new EventEmitter<number>();
-  @Output() click_back_event     = new EventEmitter<void>();
 
   message: Signal<string> = computed(() =>
     `現在実行中の作業は${this.globalState?.workKind()}です。`


### PR DESCRIPTION
## Summary
- render demo dialog from `DemoView` instead of `DemoPartsCenter`
- simplify `DemoPartsCenter` state and outputs

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `apt-get update` *(fails: repository InRelease not signed)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688f2fe2c0c8833197902aeffc911a5f