### PR TITLE
feat: enlarge dialog dimensions

### DIFF
--- a/demo/src/app/view/demo-view/parts/demo-parts-dialog/demo-parts-dialog.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-dialog/demo-parts-dialog.scss
@@ -13,8 +13,8 @@
 .dialog {
   background: #fff;
   padding: 2rem;
-  width: 32rem;
-  max-width: 90%;
+  width: 30vw;
+  height: 20vh;
   font-size: 1.2rem;
   border-radius: 1rem;
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
## Summary
- enlarge demo dialog to 30% viewport width and 20% viewport height for better visibility

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688f3de74e5883318eec7ee5d681c369