### PR TITLE
style: improve progress and selector disabled styling

### DIFF
--- a/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.scss
@@ -18,6 +18,19 @@
   text-align: center;
 }
 
+.progress {
+  font-size: 2rem;
+  font-weight: 500;
+  margin-bottom: 2.5rem;
+  color: #222f3e;
+  background: #fff;
+  padding: 1.7rem 2.7rem;
+  border-radius: 1.5rem;
+  box-shadow: 0 2px 14px 0 rgba(60,70,120,0.13);
+  letter-spacing: 0.02em;
+  text-align: center;
+}
+
 .btn-group {
   display: flex;
   gap: 2.2rem;

--- a/demo/src/app/view/demo-view/parts/demo-parts-select/demo-parts-select.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-select/demo-parts-select.scss
@@ -34,6 +34,12 @@ select {
   &:focus {
     border: 1.5px solid #43e97b;
   }
+  &:disabled {
+    background: #e2e8f0;
+    color: #94a3b8;
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- Make completed count text match the size and style of current work message
- Add explicit disabled styles for user and work selection dropdowns

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688f44225b188331b095283a10fc7b10