### PR TITLE
feat: add removable log entries

### DIFF
--- a/demo/src/app/view/demo-view/parts/demo-parts-log/demo-parts-log.html
+++ b/demo/src/app/view/demo-view/parts/demo-parts-log/demo-parts-log.html
@@ -18,7 +18,10 @@
             <td>{{ item.work }}</td>
             <td>{{ item.action }}</td>
             <td>{{ item.user }}</td>
-            <td>{{ item.timestamp }}</td>
+            <td>
+              {{ item.timestamp }}
+              <button class="log-close" (click)="remove(i)">×</button>
+            </td>
           </tr>
         }
       </tbody>

--- a/demo/src/app/view/demo-view/parts/demo-parts-log/demo-parts-log.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-log/demo-parts-log.scss
@@ -57,9 +57,31 @@
     border-bottom: 1px solid #edf2f7;
     vertical-align: middle;
     word-break: break-word;
+    position: relative;
   }
   tr:last-child td {
     border-bottom: none;
+  }
+
+  .log-close {
+    display: none;
+    position: absolute;
+    top: 50%;
+    right: 0.4rem;
+    transform: translateY(-50%);
+    border: none;
+    background: rgba(0,0,0,0.4);
+    color: #fff;
+    width: 1.2rem;
+    height: 1.2rem;
+    border-radius: 50%;
+    line-height: 1.2rem;
+    text-align: center;
+    cursor: pointer;
+  }
+
+  tr:hover .log-close {
+    display: block;
   }
 }
 

--- a/demo/src/app/view/demo-view/parts/demo-parts-log/demo-parts-log.ts
+++ b/demo/src/app/view/demo-view/parts/demo-parts-log/demo-parts-log.ts
@@ -10,4 +10,8 @@ import { DemoState } from '../../../../domain/state/global/demo-global.state';
 export class DemoPartsLog {
   private demoState = inject(DemoState);
   log = this.demoState.logs;
+
+  remove(index: number) {
+    this.demoState.deleteLog(index);
+  }
 }


### PR DESCRIPTION
## Summary
- show delete button on log rows when hovered
- allow removing a single log entry

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_688f44b266408331a09f7430fdecc411