### PR TITLE
Fix layout shifting by enforcing fixed widths for DemoView parts

### DIFF
--- a/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.scss
@@ -6,6 +6,7 @@
 }
 
 .message {
+  width: 20rem;
   font-size: 2rem;
   font-weight: 500;
   margin-bottom: 2.5rem;
@@ -19,6 +20,7 @@
 }
 
 .progress {
+  width: 20rem;
   font-size: 2rem;
   font-weight: 500;
   margin-bottom: 2.5rem;

--- a/demo/src/app/view/demo-view/parts/demo-parts-log/demo-parts-log.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-log/demo-parts-log.scss
@@ -1,5 +1,6 @@
 .log-side {
-  min-width: 350px;
+  width: 350px;
+  flex: 0 0 350px;
   margin-left: 5vw;
   background: #fff;
   border-radius: 1.4rem;

--- a/demo/src/app/view/demo-view/parts/demo-parts-select/demo-parts-select.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-select/demo-parts-select.scss
@@ -1,5 +1,6 @@
 .select-side {
-  min-width: 250px;
+  width: 250px;
+  flex: 0 0 250px;
   margin-right: 3vw;
   background: #fff;
   border-radius: 1.4rem;
@@ -23,6 +24,7 @@
 }
 
 select {
+  width: 100%;
   padding: 0.6rem 1rem;
   border-radius: 0.9rem;
   border: 1px solid #cbd5e1;


### PR DESCRIPTION
## Summary
- Prevent width changes in selection panel and log panel
- Maintain consistent message/progress box size to avoid component shifts

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688f4851cfd88331ae420a78907c84a4