### PR TITLE
Adjust component widths for log and center panels

### DIFF
--- a/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.scss
@@ -2,7 +2,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  flex: 1 1 auto;
+  width: 35vw;
+  flex: 0 0 35vw;
 }
 
 .message {
@@ -70,6 +71,8 @@
 
 @media (max-width: 900px) {
   .center-content {
+    width: 100%;
+    flex: 1 1 auto;
     margin-bottom: 2rem;
   }
 }

--- a/demo/src/app/view/demo-view/parts/demo-parts-log/demo-parts-log.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-log/demo-parts-log.scss
@@ -1,6 +1,6 @@
 .log-side {
-  width: 350px;
-  flex: 0 0 350px;
+  width: 45vw;
+  flex: 0 0 45vw;
   margin-left: 5vw;
   background: #fff;
   border-radius: 1.4rem;
@@ -34,6 +34,7 @@
   border-collapse: separate;
   border-spacing: 0;
   background: #f7fafc;
+  table-layout: fixed;
 
   thead {
     position: sticky;
@@ -44,6 +45,9 @@
   th, td {
     padding: 0.65rem 1.1rem;
     text-align: left;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   th {
     background: #eef2fb;
@@ -57,7 +61,6 @@
     color: #21283a;
     border-bottom: 1px solid #edf2f7;
     vertical-align: middle;
-    word-break: break-word;
     position: relative;
   }
   tr:last-child td {


### PR DESCRIPTION
## Summary
- expand log panel to 45% width and truncate overflowing table cells
- enlarge center panel to 35% width for better balance

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_688f50449f8883319d38679ac78a618b