### PR TITLE
Align demo view layout with fixed width segments

### DIFF
--- a/demo/src/app/view/demo-view/demo-view.scss
+++ b/demo/src/app/view/demo-view/demo-view.scss
@@ -1,11 +1,11 @@
 .demo-container {
   display: flex;
-  flex-direction: row;
+  flex-direction: row-reverse;
   height: 100vh;
-  width: 100%;
+  width: 100vw;
   box-sizing: border-box;
-  justify-content: center;
-  align-items: center;
+  justify-content: flex-start;
+  align-items: stretch;
   background: linear-gradient(110deg, #f7fafc 60%, #e3e9f3 100%);
   font-family: 'Segoe UI', 'Noto Sans JP', 'Roboto', sans-serif;
   position: relative;

--- a/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-center/demo-parts-center.scss
@@ -1,9 +1,16 @@
+:host {
+  display: block;
+  width: 35%;
+  flex: 0 0 35%;
+  box-sizing: border-box;
+}
+
 .center-content {
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 35vw;
-  flex: 0 0 35vw;
+  width: 100%;
+  flex: 1 1 auto;
 }
 
 .message {
@@ -70,9 +77,12 @@
 }
 
 @media (max-width: 900px) {
-  .center-content {
+  :host {
     width: 100%;
     flex: 1 1 auto;
+  }
+  .center-content {
+    width: 100%;
     margin-bottom: 2rem;
   }
 }

--- a/demo/src/app/view/demo-view/parts/demo-parts-log/demo-parts-log.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-log/demo-parts-log.scss
@@ -1,7 +1,13 @@
+:host {
+  display: block;
+  width: 45%;
+  flex: 0 0 45%;
+  box-sizing: border-box;
+}
+
 .log-side {
-  width: 45vw;
-  flex: 0 0 45vw;
-  margin-left: 5vw;
+  width: 100%;
+  margin-left: 0;
   background: #fff;
   border-radius: 1.4rem;
   box-shadow: 0 4px 16px 0 rgba(80,90,110,0.11);
@@ -90,6 +96,10 @@
 }
 
 @media (max-width: 900px) {
+  :host {
+    width: 100%;
+    flex: 1 1 auto;
+  }
   .log-side {
     margin-left: 0;
     margin-top: 2rem;

--- a/demo/src/app/view/demo-view/parts/demo-parts-select/demo-parts-select.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-select/demo-parts-select.scss
@@ -1,7 +1,12 @@
+:host {
+  display: block;
+  width: 20%;
+  flex: 0 0 20%;
+  box-sizing: border-box;
+}
+
 .select-side {
-  width: 250px;
-  flex: 0 0 250px;
-  margin-right: 3vw;
+  width: 100%;
   background: #fff;
   border-radius: 1.4rem;
   box-shadow: 0 4px 16px 0 rgba(80,90,110,0.11);
@@ -45,6 +50,10 @@ select {
 }
 
 @media (max-width: 900px) {
+  :host {
+    width: 100%;
+    flex: 1 1 auto;
+  }
   .select-side {
     margin-right: 0;
     margin-bottom: 2rem;


### PR DESCRIPTION
## Summary
- lay out DemoView children from right to left using flex box
- give DemoPartsSelect, DemoPartsCenter and DemoPartsLog fixed 20/35/45% widths respectively

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*
- `apt-get update` *(fails: repository is not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f592904e48331829e7726c39b2869