### PR TITLE
feat: restructure DemoView layout

### DIFF
--- a/demo/src/app/view/demo-view/demo-view.html
+++ b/demo/src/app/view/demo-view/demo-view.html
@@ -1,22 +1,28 @@
 <div class="demo-container">
-  <app-demo-parts-select
-    [globalState]="globalState"
-    [localState]="localState"
-    [userList]="userList"
-    [workList]="workList"
-    (select_user)="select_user.emit($event)"
-    (select_work)="select_work.emit($event)"
-  ></app-demo-parts-select>
-
-  <app-demo-parts-center
-    [globalState]="globalState"
-    [localState]="localState"
-    (click_complete_event)="click_complete_event.emit()"
-    (click_cancel_event)="click_cancel_event.emit()"
-    (click_execute_event)="click_execute_event.emit()"
-  ></app-demo-parts-center>
-
-  <app-demo-parts-log></app-demo-parts-log>
+  <div class="top-area">
+    <div class="top-left">
+      <app-demo-parts-select
+        [globalState]="globalState"
+        [localState]="localState"
+        [userList]="userList"
+        [workList]="workList"
+        (select_user)="select_user.emit($event)"
+        (select_work)="select_work.emit($event)"
+      ></app-demo-parts-select>
+    </div>
+    <div class="top-right">
+      <app-demo-parts-center
+        [globalState]="globalState"
+        [localState]="localState"
+        (click_complete_event)="click_complete_event.emit()"
+        (click_cancel_event)="click_cancel_event.emit()"
+        (click_execute_event)="click_execute_event.emit()"
+      ></app-demo-parts-center>
+    </div>
+  </div>
+  <div class="bottom-area">
+    <app-demo-parts-log></app-demo-parts-log>
+  </div>
 
   @if (localState.isVisibleDialog()) {
     <app-demo-parts-dialog

--- a/demo/src/app/view/demo-view/demo-view.scss
+++ b/demo/src/app/view/demo-view/demo-view.scss
@@ -1,22 +1,30 @@
 .demo-container {
-  display: flex;
-  flex-direction: row-reverse;
+  display: grid;
+  grid-template-rows: 30% 70%;
   height: 100vh;
   width: 100vw;
   box-sizing: border-box;
-  justify-content: flex-start;
-  align-items: stretch;
   background: linear-gradient(110deg, #f7fafc 60%, #e3e9f3 100%);
   font-family: 'Segoe UI', 'Noto Sans JP', 'Roboto', sans-serif;
   position: relative;
 }
 
-@media (max-width: 900px) {
-  .demo-container {
-    flex-direction: column;
-    align-items: stretch;
-    justify-content: flex-start;
-    height: 100vh;
-    padding: 1rem;
-  }
+.top-area {
+  display: grid;
+  grid-template-columns: 30% 70%;
+}
+
+.top-left,
+.top-right,
+.bottom-area {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.top-left app-demo-parts-select,
+.top-right app-demo-parts-center,
+.bottom-area app-demo-parts-log {
+  width: 97%;
+  height: 95%;
 }


### PR DESCRIPTION
## Summary
- split DemoView into top and bottom sections with nested left/right areas
- size DemoPartsSelect, DemoPartsCenter and DemoPartsLog to fit within their regions

## Testing
- `npm test` *(fails: No binary for Chrome; attempted apt-get update but repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688f62516db483319642ebd9da16b03a