### PR TITLE
feat: add counts to log entries

### DIFF
--- a/demo/src/app/domain/state/global/demo-global.state.ts
+++ b/demo/src/app/domain/state/global/demo-global.state.ts
@@ -5,6 +5,8 @@ export interface DemoLog {
   action: string;
   user: string;
   timestamp: string;
+  workCount: number;
+  completeCount: number;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -13,6 +15,8 @@ export class DemoState {
   private _userName = signal('');
   private _progress = signal(0);
   private _logs = signal<DemoLog[]>([]);
+  private _workCount = 0;
+  private _completeCount = 0;
 
   get workKind(): Signal<string> {
     return this._workKind;
@@ -38,11 +42,18 @@ export class DemoState {
   }
 
   addLog(work: string, action: string, user: string) {
+    if (action === '実行') {
+      this._workCount++;
+    } else if (action === '完了') {
+      this._completeCount++;
+    }
     const entry: DemoLog = {
       work,
       action,
       user,
-      timestamp: this.getTimestamp()
+      timestamp: this.getTimestamp(),
+      workCount: this._workCount,
+      completeCount: this._completeCount
     };
     const newLogs = [entry, ...this._logs()];
     if (newLogs.length > 20) newLogs.pop();

--- a/demo/src/app/view/demo-view/parts/demo-parts-log/demo-parts-log.html
+++ b/demo/src/app/view/demo-view/parts/demo-parts-log/demo-parts-log.html
@@ -8,6 +8,8 @@
           <th>作業</th>
           <th>処理</th>
           <th>ユーザ</th>
+          <th>作業数</th>
+          <th>完了数</th>
           <th>日時</th>
         </tr>
       </thead>
@@ -18,6 +20,8 @@
             <td>{{ item.work }}</td>
             <td>{{ item.action }}</td>
             <td>{{ item.user }}</td>
+            <td>{{ item.workCount }}</td>
+            <td>{{ item.completeCount }}</td>
             <td>
               {{ item.timestamp }}
               <button class="log-close" (click)="remove(i)">×</button>


### PR DESCRIPTION
## Summary
- track work and completion counts in log entries
- display work and completion counts in log table

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688f694aaa508331b33c8b208320720b