### PR TITLE
refactor DemoPartsLog to emit events

### DIFF
--- a/demo/src/app/domain/service/demo-service-interface.ts
+++ b/demo/src/app/domain/service/demo-service-interface.ts
@@ -10,5 +10,6 @@ export interface DemoServiceInterface {
   cancelWork()  : void;
   selectWork(work: string)  : void;
   selectUser(user: string)  : void;
+  deleteLog(index: number) : void;
   backWork(): void;
 }

--- a/demo/src/app/domain/service/impl/demo-service-impl-A.service.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-A.service.ts
@@ -47,6 +47,10 @@ export class DemoServiceImplA implements DemoServiceInterface {
     console.log('作業変更:', kind);
   }
 
+  deleteLog(index: number): void {
+    this.globalState.deleteLog(index);
+  }
+
   backWork(): void {
     // ダイアログを表示しないため何もしない
   }

--- a/demo/src/app/domain/service/impl/demo-service-impl-B.service.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-B.service.ts
@@ -43,6 +43,10 @@ export class DemoServiceImplB implements DemoServiceInterface {
     console.log('作業変更:', kind);
   }
 
+  deleteLog(index: number): void {
+    this.globalState.deleteLog(index);
+  }
+
   backWork(): void {
     // ダイアログを表示しないため何もしない
   }

--- a/demo/src/app/domain/service/impl/demo-service-impl-C.service.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-C.service.ts
@@ -48,6 +48,10 @@ export class DemoServiceImplC implements DemoServiceInterface {
     console.log('作業変更:', kind);
   }
 
+  deleteLog(index: number): void {
+    this.globalState.deleteLog(index);
+  }
+
   backWork(): void {
     this.localState.setDialogVisible(false);
   }

--- a/demo/src/app/domain/service/impl/demo-service-impl-default.service.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-default.service.ts
@@ -42,6 +42,10 @@ export class DemoServiceImplDefault implements DemoServiceInterface {
     console.log('作業' + kind + 'が選択されました。');
   }
 
+  deleteLog(index: number): void {
+    this.globalState.deleteLog(index);
+  }
+
   backWork(): void {
     // ダイアログを表示しないため何もしない
   }

--- a/demo/src/app/pages/demo-page/demo-page.html
+++ b/demo/src/app/pages/demo-page/demo-page.html
@@ -10,6 +10,7 @@
   (click_back_event)="onBack()"
   (select_user)="onSelectUser($event)"
   (select_work)="onSelectWork($event)"
+  (remove_log)="onRemoveLog($event)"
 >
 </app-demo-view>
 

--- a/demo/src/app/pages/demo-page/demo-page.ts
+++ b/demo/src/app/pages/demo-page/demo-page.ts
@@ -13,6 +13,7 @@ import { DemoServiceImplB } from '../../domain/service/impl/demo-service-impl-B.
 import { DemoServiceImplDefault } from '../../domain/service/impl/demo-service-impl-default.service';
 import { DemoServiceImplC } from '../../domain/service/impl/demo-service-impl-C.service';
 import { DemoView } from '../../view/demo-view/demo-view';
+import { DemoLog } from '../../domain/state/global/demo-global.state';
 
 @Component({
   selector: 'app-demo-page',
@@ -29,7 +30,8 @@ export class DemoPage {
   globalState = {
     workKind: signal(''),
     userName: signal(''),
-    progress: signal(0)
+    progress: signal(0),
+    logs: signal<DemoLog[]>([])
   };
   localState = {
     isEnableComplete:   signal(false),
@@ -64,6 +66,7 @@ export class DemoPage {
         this.globalState.workKind         .set( svc.globalState.workKind() );
         this.globalState.userName         .set( svc.globalState.userName() );
         this.globalState.progress         .set( svc.globalState.progress() );
+        this.globalState.logs             .set( svc.globalState.logs() );
         this.localState.isEnableComplete  .set( svc.localState.isEnableComplete() );
         this.localState.isEnableCancel    .set( svc.localState.isEnableCancel() );
         this.localState.isEnableExecute   .set( svc.localState.isEnableExecute() );
@@ -98,6 +101,10 @@ export class DemoPage {
 
   onBack() {
     this.currentService()?.backWork();
+  }
+
+  onRemoveLog(index: number) {
+    this.currentService()?.deleteLog(index);
   }
 
   onSelectUser(user: string) {

--- a/demo/src/app/view/demo-view/demo-view.html
+++ b/demo/src/app/view/demo-view/demo-view.html
@@ -23,7 +23,10 @@
   </div>
 
   <div class="bottom-area">
-    <app-demo-parts-log></app-demo-parts-log>
+    <app-demo-parts-log
+      [log]="globalState.logs"
+      (remove_log)="remove_log.emit($event)"
+    ></app-demo-parts-log>
   </div>
 
   @if (localState.isVisibleDialog()) {

--- a/demo/src/app/view/demo-view/demo-view.ts
+++ b/demo/src/app/view/demo-view/demo-view.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, Output, Signal, signal } from '@angular/core';
+import { DemoLog } from '../../domain/state/global/demo-global.state';
 import { DemoPartsSelect } from './parts/demo-parts-select/demo-parts-select';
 import { DemoPartsCenter } from './parts/demo-parts-center/demo-parts-center';
 import { DemoPartsLog } from './parts/demo-parts-log/demo-parts-log';
@@ -16,10 +17,12 @@ export class DemoView {
     workKind: Signal<string>;
     userName: Signal<string>;
     progress: Signal<number>;
+    logs: Signal<DemoLog[]>;
   } = {
     workKind: signal(''),
     userName: signal(''),
     progress: signal(0),
+    logs: signal([]),
   };
   @Input() localState: {
     isEnableComplete: Signal<boolean>;
@@ -54,5 +57,6 @@ export class DemoView {
   @Output() click_back_event     = new EventEmitter<void>();
   @Output() select_work          = new EventEmitter<string>();
   @Output() select_user          = new EventEmitter<string>();
+  @Output() remove_log           = new EventEmitter<number>();
 
 }

--- a/demo/src/app/view/demo-view/parts/demo-parts-log/demo-parts-log.ts
+++ b/demo/src/app/view/demo-view/parts/demo-parts-log/demo-parts-log.ts
@@ -1,5 +1,5 @@
-import { Component, inject } from '@angular/core';
-import { DemoState } from '../../../../domain/state/global/demo-global.state';
+import { Component, EventEmitter, Input, Output, Signal, signal } from '@angular/core';
+import { DemoLog } from '../../../../domain/state/global/demo-global.state';
 
 @Component({
   selector: 'app-demo-parts-log',
@@ -8,10 +8,10 @@ import { DemoState } from '../../../../domain/state/global/demo-global.state';
   styleUrls: ['./demo-parts-log.scss']
 })
 export class DemoPartsLog {
-  private demoState = inject(DemoState);
-  log = this.demoState.logs;
+  @Input() log: Signal<DemoLog[]> = signal([]);
+  @Output() remove_log = new EventEmitter<number>();
 
   remove(index: number) {
-    this.demoState.deleteLog(index);
+    this.remove_log.emit(index);
   }
 }


### PR DESCRIPTION
## Summary
- stop DemoPartsLog from manipulating state directly
- propagate log removal events through view and page layers
- add deleteLog to service interface and implementations

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_688f6aac53588331946470cb606846d9