### PR TITLE
fix: ensure dialog overlay on top of log header

### DIFF
--- a/demo/src/app/view/demo-view/parts/demo-parts-dialog/demo-parts-dialog.scss
+++ b/demo/src/app/view/demo-view/parts/demo-parts-dialog/demo-parts-dialog.scss
@@ -8,9 +8,11 @@
   align-items: center;
   justify-content: center;
   background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
 }
 
 .dialog {
+  position: relative;
   background: #fff;
   padding: 2rem;
   width: 30vw;
@@ -18,6 +20,7 @@
   font-size: 1.2rem;
   border-radius: 1rem;
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+  z-index: 1001;
 }
 
 .count-box {


### PR DESCRIPTION
## Summary
- raise z-index of dialog overlay so it sits above log header

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688f6d449c448331b395ca4c2250225b