### PR TITLE
Fix log work and completion counts

### DIFF
--- a/demo/src/app/domain/service/impl/demo-service-impl-A.service.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-A.service.ts
@@ -17,7 +17,12 @@ export class DemoServiceImplA implements DemoServiceInterface {
   executeWork(count: number): void {
     console.log('作業A実行');
     this.globalState.updateProgress(count);
-    this.globalState.addLog(this.globalState.workKind(), '実行', this.globalState.userName());
+    this.globalState.addLog(
+      this.globalState.workKind(),
+      '実行',
+      this.globalState.userName(),
+      count
+    );
   }
 
   completeWork(): void {

--- a/demo/src/app/domain/service/impl/demo-service-impl-B.service.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-B.service.ts
@@ -13,7 +13,12 @@ export class DemoServiceImplB implements DemoServiceInterface {
   executeWork(count: number): void {
     console.log('作業B実行');
     this.globalState.updateProgress(count);
-    this.globalState.addLog(this.globalState.workKind(), '実行', this.globalState.userName());
+    this.globalState.addLog(
+      this.globalState.workKind(),
+      '実行',
+      this.globalState.userName(),
+      count
+    );
   }
 
   completeWork(): void {

--- a/demo/src/app/domain/service/impl/demo-service-impl-C.service.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-C.service.ts
@@ -17,7 +17,12 @@ export class DemoServiceImplC implements DemoServiceInterface {
     }
     console.log('作業C実行');
     this.globalState.updateProgress(count);
-    this.globalState.addLog(this.globalState.workKind(), '実行', this.globalState.userName());
+    this.globalState.addLog(
+      this.globalState.workKind(),
+      '実行',
+      this.globalState.userName(),
+      count
+    );
     this.localState.setDialogVisible(false);
   }
 

--- a/demo/src/app/domain/state/global/demo-global.state.ts
+++ b/demo/src/app/domain/state/global/demo-global.state.ts
@@ -15,8 +15,6 @@ export class DemoState {
   private _userName = signal('');
   private _progress = signal(0);
   private _logs = signal<DemoLog[]>([]);
-  private _workCount = 0;
-  private _completeCount = 0;
 
   get workKind(): Signal<string> {
     return this._workKind;
@@ -41,19 +39,14 @@ export class DemoState {
     this._progress.set(0);
   }
 
-  addLog(work: string, action: string, user: string) {
-    if (action === '実行') {
-      this._workCount++;
-    } else if (action === '完了') {
-      this._completeCount++;
-    }
+  addLog(work: string, action: string, user: string, workCount = 0) {
     const entry: DemoLog = {
       work,
       action,
       user,
       timestamp: this.getTimestamp(),
-      workCount: this._workCount,
-      completeCount: this._completeCount
+      workCount: action === '実行' ? workCount : 0,
+      completeCount: action === '完了' ? this._progress() : 0
     };
     const newLogs = [entry, ...this._logs()];
     if (newLogs.length > 20) newLogs.pop();


### PR DESCRIPTION
## Summary
- record executed progress and completion totals in log entries
- pass progress increments from services A/B/C to logging

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_688f6fbe6a208331aef903c3b4c33eec