### PR TITLE
refactor: pass values to view components

### DIFF
--- a/demo/src/app/pages/demo-page/demo-page.ts
+++ b/demo/src/app/pages/demo-page/demo-page.ts
@@ -3,7 +3,6 @@ import {
   effect,
   runInInjectionContext,
   signal,
-  Signal,
   inject,
   EnvironmentInjector
 } from '@angular/core';
@@ -26,24 +25,24 @@ export class DemoPage {
   workList = ['作業A', '作業B', '作業C'];
   userList = ['Aoki', 'Yamada', 'Suzuki', 'Tanaka'];
 
-  // 子に渡す中継シグナル
+  // 子に渡す値
   globalState = {
-    workKind: signal(''),
-    userName: signal(''),
-    progress: signal(0),
-    logs: signal<DemoLog[]>([])
+    workKind: '',
+    userName: '',
+    progress: 0,
+    logs: [] as DemoLog[],
   };
   localState = {
-    isEnableComplete:   signal(false),
-    isEnableCancel:     signal(false),
-    isEnableExecute:    signal(false),
-    isEnableSelectUser: signal(false),
-    isEnableSelectWork: signal(false),
-    isVisibleDialog:    signal(false),
-    isEnablePlus:       signal(true),
-    isEnableMinus:      signal(true),
-    isEnableDecide:     signal(true),
-    isEnableBack:       signal(true)
+    isEnableComplete:   false,
+    isEnableCancel:     false,
+    isEnableExecute:    false,
+    isEnableSelectUser: false,
+    isEnableSelectWork: false,
+    isVisibleDialog:    false,
+    isEnablePlus:       true,
+    isEnableMinus:      true,
+    isEnableDecide:     true,
+    isEnableBack:       true,
   };
 
   // 「今のサービス」を保持する Signal。最初は undefined でOK。
@@ -63,20 +62,20 @@ export class DemoPage {
       effect(() => {
         const svc = this.currentService();
         if (!svc) return;
-        this.globalState.workKind         .set( svc.globalState.workKind() );
-        this.globalState.userName         .set( svc.globalState.userName() );
-        this.globalState.progress         .set( svc.globalState.progress() );
-        this.globalState.logs             .set( svc.globalState.logs() );
-        this.localState.isEnableComplete  .set( svc.localState.isEnableComplete() );
-        this.localState.isEnableCancel    .set( svc.localState.isEnableCancel() );
-        this.localState.isEnableExecute   .set( svc.localState.isEnableExecute() );
-        this.localState.isEnableSelectUser.set( svc.localState.isEnableSelectUser() );
-        this.localState.isEnableSelectWork.set( svc.localState.isEnableSelectWork() );
-        this.localState.isVisibleDialog   .set( svc.localState.isVisibleDialog() );
-        this.localState.isEnablePlus      .set( svc.localState.isEnablePlus() );
-        this.localState.isEnableMinus     .set( svc.localState.isEnableMinus() );
-        this.localState.isEnableDecide    .set( svc.localState.isEnableDecide() );
-        this.localState.isEnableBack      .set( svc.localState.isEnableBack() );
+        this.globalState.workKind          = svc.globalState.workKind();
+        this.globalState.userName          = svc.globalState.userName();
+        this.globalState.progress          = svc.globalState.progress();
+        this.globalState.logs              = svc.globalState.logs();
+        this.localState.isEnableComplete   = svc.localState.isEnableComplete();
+        this.localState.isEnableCancel     = svc.localState.isEnableCancel();
+        this.localState.isEnableExecute    = svc.localState.isEnableExecute();
+        this.localState.isEnableSelectUser = svc.localState.isEnableSelectUser();
+        this.localState.isEnableSelectWork = svc.localState.isEnableSelectWork();
+        this.localState.isVisibleDialog    = svc.localState.isVisibleDialog();
+        this.localState.isEnablePlus       = svc.localState.isEnablePlus();
+        this.localState.isEnableMinus      = svc.localState.isEnableMinus();
+        this.localState.isEnableDecide     = svc.localState.isEnableDecide();
+        this.localState.isEnableBack       = svc.localState.isEnableBack();
       });
     });
   }

--- a/demo/src/app/view/demo-view/demo-view.html
+++ b/demo/src/app/view/demo-view/demo-view.html
@@ -29,7 +29,7 @@
     ></app-demo-parts-log>
   </div>
 
-  @if (localState.isVisibleDialog()) {
+  @if (localState.isVisibleDialog) {
     <app-demo-parts-dialog
       [localState]="localState"
       (click_decide_event)="click_decide_event.emit($event)"

--- a/demo/src/app/view/demo-view/demo-view.ts
+++ b/demo/src/app/view/demo-view/demo-view.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, Signal, signal } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { DemoLog } from '../../domain/state/global/demo-global.state';
 import { DemoPartsSelect } from '../parts/demo-parts-select/demo-parts-select';
 import { DemoPartsCenter } from '../parts/demo-parts-center/demo-parts-center';
@@ -14,38 +14,38 @@ import { DemoPartsDialog } from '../parts/demo-parts-dialog/demo-parts-dialog';
 })
 export class DemoView {
   @Input() globalState: {
-    workKind: Signal<string>;
-    userName: Signal<string>;
-    progress: Signal<number>;
-    logs: Signal<DemoLog[]>;
+    workKind: string;
+    userName: string;
+    progress: number;
+    logs: DemoLog[];
   } = {
-    workKind: signal(''),
-    userName: signal(''),
-    progress: signal(0),
-    logs: signal([]),
+    workKind: '',
+    userName: '',
+    progress: 0,
+    logs: [],
   };
   @Input() localState: {
-    isEnableComplete: Signal<boolean>;
-    isEnableCancel: Signal<boolean>;
-    isEnableExecute: Signal<boolean>;
-    isEnableSelectUser: Signal<boolean>;
-    isEnableSelectWork: Signal<boolean>;
-    isVisibleDialog: Signal<boolean>;
-    isEnablePlus: Signal<boolean>;
-    isEnableMinus: Signal<boolean>;
-    isEnableDecide: Signal<boolean>;
-    isEnableBack: Signal<boolean>;
+    isEnableComplete: boolean;
+    isEnableCancel: boolean;
+    isEnableExecute: boolean;
+    isEnableSelectUser: boolean;
+    isEnableSelectWork: boolean;
+    isVisibleDialog: boolean;
+    isEnablePlus: boolean;
+    isEnableMinus: boolean;
+    isEnableDecide: boolean;
+    isEnableBack: boolean;
   } = {
-    isEnableComplete: signal(false),
-    isEnableCancel: signal(false),
-    isEnableExecute: signal(false),
-    isEnableSelectUser: signal(false),
-    isEnableSelectWork: signal(false),
-    isVisibleDialog: signal(false),
-    isEnablePlus: signal(true),
-    isEnableMinus: signal(true),
-    isEnableDecide: signal(true),
-    isEnableBack: signal(true)
+    isEnableComplete: false,
+    isEnableCancel: false,
+    isEnableExecute: false,
+    isEnableSelectUser: false,
+    isEnableSelectWork: false,
+    isVisibleDialog: false,
+    isEnablePlus: true,
+    isEnableMinus: true,
+    isEnableDecide: true,
+    isEnableBack: true,
   };
   @Input() userList: string[] = [];
   @Input() workList: string[] = [];

--- a/demo/src/app/view/parts/demo-parts-center/demo-parts-center.html
+++ b/demo/src/app/view/parts/demo-parts-center/demo-parts-center.html
@@ -1,28 +1,28 @@
 <div class="center-content">
   <div class="message">
-    {{ message() }}
+    {{ message }}
   </div>
   <div class="progress">
-    {{ progressMessage() }}
+    {{ progressMessage }}
   </div>
   <div class="btn-group">
     <button
       class="action-btn complete"
-      [disabled]="!localState.isEnableComplete()"
+      [disabled]="!localState.isEnableComplete"
       (click)="onClickCompleteBtn()"
     >
       完了
     </button>
     <button
       class="action-btn cancel"
-      [disabled]="!localState.isEnableCancel()"
+      [disabled]="!localState.isEnableCancel"
       (click)="onClickCancelBtn()"
     >
       キャンセル
     </button>
     <button
       class="action-btn execute"
-      [disabled]="!localState.isEnableExecute()"
+      [disabled]="!localState.isEnableExecute"
       (click)="onClickExecuteBtn()"
     >
       実行

--- a/demo/src/app/view/parts/demo-parts-center/demo-parts-center.ts
+++ b/demo/src/app/view/parts/demo-parts-center/demo-parts-center.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, Signal, computed, signal } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'app-demo-parts-center',
@@ -7,31 +7,31 @@ import { Component, EventEmitter, Input, Output, Signal, computed, signal } from
   styleUrls: ['./demo-parts-center.scss']
 })
 export class DemoPartsCenter {
-  @Input() globalState: { workKind: Signal<string>; progress: Signal<number> } = {
-    workKind: signal(''),
-    progress: signal(0)
+  @Input() globalState: { workKind: string; progress: number } = {
+    workKind: '',
+    progress: 0,
   };
   @Input() localState: {
-    isEnableComplete: Signal<boolean>;
-    isEnableCancel: Signal<boolean>;
-    isEnableExecute: Signal<boolean>;
+    isEnableComplete: boolean;
+    isEnableCancel: boolean;
+    isEnableExecute: boolean;
   } = {
-    isEnableComplete: signal(false),
-    isEnableCancel: signal(false),
-    isEnableExecute: signal(false)
+    isEnableComplete: false,
+    isEnableCancel: false,
+    isEnableExecute: false,
   };
 
   @Output() click_complete_event = new EventEmitter<void>();
   @Output() click_cancel_event   = new EventEmitter<void>();
   @Output() click_execute_event  = new EventEmitter<void>();
 
-  message: Signal<string> = computed(() =>
-    `現在実行中の作業は${this.globalState?.workKind()}です。`
-  );
+  get message(): string {
+    return `現在実行中の作業は${this.globalState?.workKind}です。`;
+  }
 
-  progressMessage: Signal<string> = computed(() =>
-    `完了数：${this.globalState?.progress()}`
-  );
+  get progressMessage(): string {
+    return `完了数：${this.globalState?.progress}`;
+  }
 
   onClickCompleteBtn() {
     this.click_complete_event.emit();

--- a/demo/src/app/view/parts/demo-parts-dialog/demo-parts-dialog.html
+++ b/demo/src/app/view/parts/demo-parts-dialog/demo-parts-dialog.html
@@ -3,14 +3,14 @@
     <div class="dialog-content">
       <span>作業数：</span>
       <div class="count-box">
-        <button (click)="onClickPlusBtn()" [disabled]="!localState.isEnablePlus()">+</button>
+        <button (click)="onClickPlusBtn()" [disabled]="!localState.isEnablePlus">+</button>
         <div class="count-display">{{ workCount }}</div>
-        <button (click)="onClickMinusBtn()" [disabled]="!localState.isEnableMinus()">-</button>
+        <button (click)="onClickMinusBtn()" [disabled]="!localState.isEnableMinus">-</button>
       </div>
     </div>
     <div class="dialog-actions">
-      <button (click)="onClickDecideBtn()" [disabled]="!localState.isEnableDecide()">決定</button>
-      <button (click)="onClickBackBtn()" [disabled]="!localState.isEnableBack()">戻る</button>
+      <button (click)="onClickDecideBtn()" [disabled]="!localState.isEnableDecide">決定</button>
+      <button (click)="onClickBackBtn()" [disabled]="!localState.isEnableBack">戻る</button>
     </div>
   </div>
 </div>

--- a/demo/src/app/view/parts/demo-parts-dialog/demo-parts-dialog.ts
+++ b/demo/src/app/view/parts/demo-parts-dialog/demo-parts-dialog.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, Signal, signal } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'app-demo-parts-dialog',
@@ -8,15 +8,15 @@ import { Component, EventEmitter, Input, Output, Signal, signal } from '@angular
 })
 export class DemoPartsDialog {
   @Input() localState: {
-    isEnablePlus: Signal<boolean>;
-    isEnableMinus: Signal<boolean>;
-    isEnableDecide: Signal<boolean>;
-    isEnableBack: Signal<boolean>;
+    isEnablePlus: boolean;
+    isEnableMinus: boolean;
+    isEnableDecide: boolean;
+    isEnableBack: boolean;
   } = {
-    isEnablePlus: signal(true),
-    isEnableMinus: signal(true),
-    isEnableDecide: signal(true),
-    isEnableBack: signal(true)
+    isEnablePlus: true,
+    isEnableMinus: true,
+    isEnableDecide: true,
+    isEnableBack: true,
   };
 
   @Output() click_decide_event = new EventEmitter<number>();

--- a/demo/src/app/view/parts/demo-parts-log/demo-parts-log.html
+++ b/demo/src/app/view/parts/demo-parts-log/demo-parts-log.html
@@ -14,7 +14,7 @@
         </tr>
       </thead>
       <tbody>
-        @for (item of log(); track $index; let i = $index) {
+        @for (item of log; track $index; let i = $index) {
           <tr>
             <td>{{ i + 1 }}</td>
             <td>{{ item.work }}</td>

--- a/demo/src/app/view/parts/demo-parts-log/demo-parts-log.ts
+++ b/demo/src/app/view/parts/demo-parts-log/demo-parts-log.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, Signal, signal } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { DemoLog } from '../../../domain/state/global/demo-global.state';
 
 @Component({
@@ -8,7 +8,7 @@ import { DemoLog } from '../../../domain/state/global/demo-global.state';
   styleUrls: ['./demo-parts-log.scss']
 })
 export class DemoPartsLog {
-  @Input() log: Signal<DemoLog[]> = signal([]);
+  @Input() log: DemoLog[] = [];
   @Output() remove_log = new EventEmitter<number>();
 
   remove(index: number) {

--- a/demo/src/app/view/parts/demo-parts-select/demo-parts-select.html
+++ b/demo/src/app/view/parts/demo-parts-select/demo-parts-select.html
@@ -3,9 +3,9 @@
     <label class="dropdown-label" for="userSelect">ユーザー選択</label>
     <select
       id="userSelect"
-      [value]="globalState.userName()"
+      [value]="globalState.userName"
       (change)="onSelectUser($event)"
-      [disabled]="!localState.isEnableSelectUser()"
+      [disabled]="!localState.isEnableSelectUser"
     >
       <option value="" disabled>ユーザを選択。</option>
       @for (user of userList; track user; let i = $index) {
@@ -17,9 +17,9 @@
     <label class="dropdown-label" for="workSelect">作業選択</label>
     <select
       id="workSelect"
-      [value]="globalState.workKind()"
+      [value]="globalState.workKind"
       (change)="onSelectWork($event)"
-      [disabled]="!localState.isEnableSelectWork()"
+      [disabled]="!localState.isEnableSelectWork"
     >
       <option value="未確認" disabled>作業を選択。</option>
       @for (work of workList; track work; let i = $index) {

--- a/demo/src/app/view/parts/demo-parts-select/demo-parts-select.ts
+++ b/demo/src/app/view/parts/demo-parts-select/demo-parts-select.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, Signal, signal } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'app-demo-parts-select',
@@ -7,16 +7,16 @@ import { Component, EventEmitter, Input, Output, Signal, signal } from '@angular
   styleUrls: ['./demo-parts-select.scss']
 })
 export class DemoPartsSelect {
-  @Input() globalState: { workKind: Signal<string>; userName: Signal<string> } = {
-    workKind: signal(''),
-    userName: signal('')
+  @Input() globalState: { workKind: string; userName: string } = {
+    workKind: '',
+    userName: '',
   };
   @Input() localState: {
-    isEnableSelectUser: Signal<boolean>;
-    isEnableSelectWork: Signal<boolean>;
+    isEnableSelectUser: boolean;
+    isEnableSelectWork: boolean;
   } = {
-    isEnableSelectUser: signal(false),
-    isEnableSelectWork: signal(false)
+    isEnableSelectUser: false,
+    isEnableSelectWork: false,
   };
   @Input() userList: string[] = [];
   @Input() workList: string[] = [];


### PR DESCRIPTION
## Summary
- pass plain values from container to view instead of Signals
- update DemoView and parts components to consume value inputs

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6890230d6b008331966bbd5c98c525d5