### PR TITLE
feat(state): persist signals to local storage

### DIFF
--- a/demo/src/app/domain/state/global/demo-global.state.ts
+++ b/demo/src/app/domain/state/global/demo-global.state.ts
@@ -1,4 +1,5 @@
 import { Injectable, signal, Signal } from '@angular/core';
+import { PersistentStateAuto } from '../utils/persistent-state-auto';
 
 export interface DemoLog {
   work: string;
@@ -10,7 +11,11 @@ export interface DemoLog {
 }
 
 @Injectable({ providedIn: 'root' })
-export class DemoState {
+export class DemoState extends PersistentStateAuto {
+  constructor() {
+    super('demo-state');
+  }
+
   private _workKind = signal('未確認');
   private _userName = signal('');
   private _progress = signal(0);

--- a/demo/src/app/domain/state/utils/persistent-state-auto.ts
+++ b/demo/src/app/domain/state/utils/persistent-state-auto.ts
@@ -1,0 +1,86 @@
+import { WritableSignal, effect } from '@angular/core';
+
+export abstract class PersistentStateAuto {
+  constructor(private readonly storageKey: string) {
+    const saved = localStorage.getItem(this.storageKey);
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        this.restoreSignals(parsed);
+      } catch (e) {
+        console.warn(`[${this.storageKey}] Failed to parse localStorage:`, e);
+      }
+    }
+
+    // 自動保存
+    effect(() => this.autoSave());
+
+    // Signal変更のログ記録
+    this.setupLogging();
+  }
+
+  // 保存対象の制限（null = 全Signal）
+  protected getPersistedKeys(): string[] | null {
+    return null;
+  }
+
+  // ログを取りたいSignalのキー（null = ログ無効）
+  protected getLoggableKeys(): string[] | null {
+    return null;
+  }
+
+  private isWritableSignal(candidate: unknown): candidate is WritableSignal<unknown> {
+    return (
+      typeof candidate === 'function' &&
+      typeof (candidate as any).set === 'function' &&
+      typeof (candidate as any).asReadonly === 'function'
+    );
+  }
+
+  private autoSave() {
+    const state: Record<string, unknown> = {};
+    const persistedKeys = this.getPersistedKeys();
+
+    for (const key of Object.keys(this)) {
+      if (persistedKeys && !persistedKeys.includes(key)) continue;
+
+      const value = (this as any)[key];
+      if (this.isWritableSignal(value)) {
+        state[key] = value();
+      }
+    }
+
+    localStorage.setItem(this.storageKey, JSON.stringify(state));
+  }
+
+  private restoreSignals(savedState: Record<string, unknown>) {
+    for (const [key, val] of Object.entries(savedState)) {
+      const target = (this as any)[key];
+      if (this.isWritableSignal(target)) {
+        target.set(val);
+      }
+    }
+  }
+
+  // ✅ Signalの変更を effect で監視し、ログ出力
+  private setupLogging() {
+    const loggableKeys = this.getLoggableKeys();
+    if (!loggableKeys) return;
+
+    for (const key of loggableKeys) {
+      const signalCandidate = (this as any)[key];
+      if (this.isWritableSignal(signalCandidate)) {
+        let previous = signalCandidate();
+        effect(() => {
+          const current = signalCandidate();
+          if (previous !== current) {
+            console.log(`📋 [${this.storageKey}] ${key} changed:`, previous, '→', current);
+            previous = current;
+          }
+        });
+      } else {
+        console.warn(`🔍 Cannot watch key "${key}" - not a WritableSignal`);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add PersistentStateAuto utility to auto-save WritableSignals and log updates
- persist DemoState signals to local storage via new utility

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6891f301f8d0833186202e3a3bc1ecaa