### PR TITLE
globalStateとlocalStateをWritableSignalで宣言

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,7 @@ The frontend file structure and responsibilities are as follows:
 * Act as container components.
 * Responsible for mapping events emitted from View components to appropriate methods in Service classes.
 * Retrieve state from State classes through Service classes and pass the state to View components.
+
+### 3. Signal Declaration
+
+* globalStateやlocalStateで使用するSignalは、`computed`などによる読み取り専用のケースを除き、`WritableSignal`で宣言してください。

--- a/demo/src/app/domain/state/demo-local-state-interface.ts
+++ b/demo/src/app/domain/state/demo-local-state-interface.ts
@@ -1,4 +1,4 @@
-import { Signal } from "@angular/core";
+import { Signal, WritableSignal } from "@angular/core";
 
 export interface DemoLocalState {
   readonly isEnableComplete  : Signal<boolean>;
@@ -6,9 +6,9 @@ export interface DemoLocalState {
   readonly isEnableExecute   : Signal<boolean>;
   readonly isEnableSelectUser: Signal<boolean>;
   readonly isEnableSelectWork: Signal<boolean>;
-  readonly isVisibleDialog   : Signal<boolean>;
-  readonly isEnablePlus      : Signal<boolean>;
-  readonly isEnableMinus     : Signal<boolean>;
-  readonly isEnableDecide    : Signal<boolean>;
-  readonly isEnableBack      : Signal<boolean>;
+  readonly isVisibleDialog   : WritableSignal<boolean>;
+  readonly isEnablePlus      : WritableSignal<boolean>;
+  readonly isEnableMinus     : WritableSignal<boolean>;
+  readonly isEnableDecide    : WritableSignal<boolean>;
+  readonly isEnableBack      : WritableSignal<boolean>;
 }

--- a/demo/src/app/domain/state/global/demo-global.state.ts
+++ b/demo/src/app/domain/state/global/demo-global.state.ts
@@ -1,4 +1,4 @@
-import { Injectable, signal, Signal } from '@angular/core';
+import { Injectable, signal, WritableSignal } from '@angular/core';
 import { PersistentStateAuto } from '../utils/persistent-state-auto';
 
 export interface DemoLog {
@@ -16,22 +16,22 @@ export class DemoState extends PersistentStateAuto {
     super('demo-state');
   }
 
-  private _workKind = signal('未確認');
-  private _userName = signal('');
-  private _progress = signal(0);
-  private _logs = signal<DemoLog[]>([]);
+  private _workKind: WritableSignal<string> = signal('未確認');
+  private _userName: WritableSignal<string> = signal('');
+  private _progress: WritableSignal<number> = signal(0);
+  private _logs: WritableSignal<DemoLog[]> = signal<DemoLog[]>([]);
 
-  get workKind(): Signal<string> {
+  get workKind(): WritableSignal<string> {
     return this._workKind;
   }
-  get userName(): Signal<string> {
+  get userName(): WritableSignal<string> {
     return this._userName;
   }
-  get progress(): Signal<number> {
+  get progress(): WritableSignal<number> {
     return this._progress;
   }
 
-  get logs(): Signal<DemoLog[]> {
+  get logs(): WritableSignal<DemoLog[]> {
     return this._logs;
   }
 

--- a/demo/src/app/domain/state/local/demo-local-A.state.ts
+++ b/demo/src/app/domain/state/local/demo-local-A.state.ts
@@ -1,4 +1,4 @@
-import { computed, Injectable, Signal, signal } from "@angular/core";
+import { computed, Injectable, Signal, signal, WritableSignal } from "@angular/core";
 import { DemoState } from "../global/demo-global.state";
 import { DemoLocalState } from "../demo-local-state-interface";
 import { PersistentStateAuto } from "../utils/persistent-state-auto";
@@ -15,11 +15,11 @@ export class DemoLocalStateA extends PersistentStateAuto implements DemoLocalSta
   private _isEnableExecute  = computed(() => this.globalState.progress() < 10);
   private _isEnableSelectUser = computed(() => false);
   private _isEnableSelectWork = computed(() => false);
-  private _isVisibleDialog = signal(false);
-  private _isEnablePlus   = signal(true);
-  private _isEnableMinus  = signal(true);
-  private _isEnableDecide = signal(true);
-  private _isEnableBack   = signal(true);
+  private _isVisibleDialog: WritableSignal<boolean> = signal(false);
+  private _isEnablePlus:   WritableSignal<boolean> = signal(true);
+  private _isEnableMinus:  WritableSignal<boolean> = signal(true);
+  private _isEnableDecide: WritableSignal<boolean> = signal(true);
+  private _isEnableBack:   WritableSignal<boolean> = signal(true);
 
   get isEnableComplete(): Signal<boolean> {
     return this._isEnableComplete;
@@ -36,19 +36,19 @@ export class DemoLocalStateA extends PersistentStateAuto implements DemoLocalSta
   get isEnableSelectWork(): Signal<boolean> {
     return this._isEnableSelectWork;
   }
-  get isVisibleDialog(): Signal<boolean> {
+  get isVisibleDialog(): WritableSignal<boolean> {
     return this._isVisibleDialog;
   }
-  get isEnablePlus(): Signal<boolean> {
+  get isEnablePlus(): WritableSignal<boolean> {
     return this._isEnablePlus;
   }
-  get isEnableMinus(): Signal<boolean> {
+  get isEnableMinus(): WritableSignal<boolean> {
     return this._isEnableMinus;
   }
-  get isEnableDecide(): Signal<boolean> {
+  get isEnableDecide(): WritableSignal<boolean> {
     return this._isEnableDecide;
   }
-  get isEnableBack(): Signal<boolean> {
+  get isEnableBack(): WritableSignal<boolean> {
     return this._isEnableBack;
   }
 }

--- a/demo/src/app/domain/state/local/demo-local-B.state.ts
+++ b/demo/src/app/domain/state/local/demo-local-B.state.ts
@@ -1,4 +1,4 @@
-import { computed, Injectable, Signal, signal } from "@angular/core";
+import { computed, Injectable, Signal, signal, WritableSignal } from "@angular/core";
 import { DemoState } from "../global/demo-global.state";
 import { DemoLocalState } from "../demo-local-state-interface";
 import { PersistentStateAuto } from "../utils/persistent-state-auto";
@@ -15,11 +15,11 @@ export class DemoLocalStateB extends PersistentStateAuto implements DemoLocalSta
   private _isEnableExecute  = computed(() => this.globalState.progress() < 7);
   private _isEnableSelectUser = computed(() => false);
   private _isEnableSelectWork = computed(() => false);
-  private _isVisibleDialog = signal(false);
-  private _isEnablePlus   = signal(true);
-  private _isEnableMinus  = signal(true);
-  private _isEnableDecide = signal(true);
-  private _isEnableBack   = signal(true);
+  private _isVisibleDialog: WritableSignal<boolean> = signal(false);
+  private _isEnablePlus:   WritableSignal<boolean> = signal(true);
+  private _isEnableMinus:  WritableSignal<boolean> = signal(true);
+  private _isEnableDecide: WritableSignal<boolean> = signal(true);
+  private _isEnableBack:   WritableSignal<boolean> = signal(true);
 
   get isEnableComplete(): Signal<boolean> {
     return this._isEnableComplete;
@@ -36,19 +36,19 @@ export class DemoLocalStateB extends PersistentStateAuto implements DemoLocalSta
   get isEnableSelectWork(): Signal<boolean> {
     return this._isEnableSelectWork;
   }
-  get isVisibleDialog(): Signal<boolean> {
+  get isVisibleDialog(): WritableSignal<boolean> {
     return this._isVisibleDialog;
   }
-  get isEnablePlus(): Signal<boolean> {
+  get isEnablePlus(): WritableSignal<boolean> {
     return this._isEnablePlus;
   }
-  get isEnableMinus(): Signal<boolean> {
+  get isEnableMinus(): WritableSignal<boolean> {
     return this._isEnableMinus;
   }
-  get isEnableDecide(): Signal<boolean> {
+  get isEnableDecide(): WritableSignal<boolean> {
     return this._isEnableDecide;
   }
-  get isEnableBack(): Signal<boolean> {
+  get isEnableBack(): WritableSignal<boolean> {
     return this._isEnableBack;
   }
 }

--- a/demo/src/app/domain/state/local/demo-local-C.state.ts
+++ b/demo/src/app/domain/state/local/demo-local-C.state.ts
@@ -1,4 +1,4 @@
-import { computed, Injectable, Signal, signal } from '@angular/core';
+import { computed, Injectable, Signal, signal, WritableSignal } from '@angular/core';
 import { DemoState } from '../global/demo-global.state';
 import { DemoLocalState } from '../demo-local-state-interface';
 import { PersistentStateAuto } from '../utils/persistent-state-auto';
@@ -15,22 +15,22 @@ export class DemoLocalStateC extends PersistentStateAuto implements DemoLocalSta
   private _isEnableSelectUser = computed(() => false);
   private _isEnableSelectWork = computed(() => false);
 
-  private _isVisibleDialog = signal(false);
-  private _isEnablePlus    = signal(true);
-  private _isEnableMinus   = signal(true);
-  private _isEnableDecide  = signal(true);
-  private _isEnableBack    = signal(true);
+  private _isVisibleDialog: WritableSignal<boolean> = signal(false);
+  private _isEnablePlus:    WritableSignal<boolean> = signal(true);
+  private _isEnableMinus:   WritableSignal<boolean> = signal(true);
+  private _isEnableDecide:  WritableSignal<boolean> = signal(true);
+  private _isEnableBack:    WritableSignal<boolean> = signal(true);
 
   get isEnableComplete()  : Signal<boolean> { return this._isEnableComplete; }
   get isEnableCancel()    : Signal<boolean> { return this._isEnableCancel; }
   get isEnableExecute()   : Signal<boolean> { return this._isEnableExecute; }
   get isEnableSelectUser(): Signal<boolean> { return this._isEnableSelectUser; }
   get isEnableSelectWork(): Signal<boolean> { return this._isEnableSelectWork; }
-  get isVisibleDialog()   : Signal<boolean> { return this._isVisibleDialog; }
-  get isEnablePlus()      : Signal<boolean> { return this._isEnablePlus; }
-  get isEnableMinus()     : Signal<boolean> { return this._isEnableMinus; }
-  get isEnableDecide()    : Signal<boolean> { return this._isEnableDecide; }
-  get isEnableBack()      : Signal<boolean> { return this._isEnableBack; }
+  get isVisibleDialog()   : WritableSignal<boolean> { return this._isVisibleDialog; }
+  get isEnablePlus()      : WritableSignal<boolean> { return this._isEnablePlus; }
+  get isEnableMinus()     : WritableSignal<boolean> { return this._isEnableMinus; }
+  get isEnableDecide()    : WritableSignal<boolean> { return this._isEnableDecide; }
+  get isEnableBack()      : WritableSignal<boolean> { return this._isEnableBack; }
 
   setDialogVisible(flag: boolean) {
     this._isVisibleDialog.set(flag);

--- a/demo/src/app/domain/state/local/demo-local-default.state.ts
+++ b/demo/src/app/domain/state/local/demo-local-default.state.ts
@@ -1,4 +1,4 @@
-import { Injectable, signal, Signal } from "@angular/core";
+import { Injectable, signal, WritableSignal } from "@angular/core";
 import { DemoState } from "../global/demo-global.state";
 import { DemoLocalState } from "../demo-local-state-interface";
 import { PersistentStateAuto } from "../utils/persistent-state-auto";
@@ -10,45 +10,45 @@ export class DemoLocalStateDefault extends PersistentStateAuto implements DemoLo
     super('demo-local-state-default');
   }
 
-  private _isEnableComplete = signal(false);
-  private _isEnableCancel   = signal(false);
-  private _isEnableExecute  = signal(false);
-  private _isEnableSelectUser = signal(true);
-  private _isEnableSelectWork = signal(true);
-  private _isVisibleDialog = signal(false);
-  private _isEnablePlus   = signal(true);
-  private _isEnableMinus  = signal(true);
-  private _isEnableDecide = signal(true);
-  private _isEnableBack   = signal(true);
+  private _isEnableComplete:   WritableSignal<boolean> = signal(false);
+  private _isEnableCancel:     WritableSignal<boolean> = signal(false);
+  private _isEnableExecute:    WritableSignal<boolean> = signal(false);
+  private _isEnableSelectUser: WritableSignal<boolean> = signal(true);
+  private _isEnableSelectWork: WritableSignal<boolean> = signal(true);
+  private _isVisibleDialog:    WritableSignal<boolean> = signal(false);
+  private _isEnablePlus:       WritableSignal<boolean> = signal(true);
+  private _isEnableMinus:      WritableSignal<boolean> = signal(true);
+  private _isEnableDecide:     WritableSignal<boolean> = signal(true);
+  private _isEnableBack:       WritableSignal<boolean> = signal(true);
 
-  get isEnableComplete(): Signal<boolean> {
+  get isEnableComplete(): WritableSignal<boolean> {
     return this._isEnableComplete;
   }
-  get isEnableCancel(): Signal<boolean> {
+  get isEnableCancel(): WritableSignal<boolean> {
     return this._isEnableCancel;
   }
-  get isEnableExecute(): Signal<boolean> {
+  get isEnableExecute(): WritableSignal<boolean> {
     return this._isEnableExecute;
   }
-  get isEnableSelectUser(): Signal<boolean> {
+  get isEnableSelectUser(): WritableSignal<boolean> {
     return this._isEnableSelectUser;
   }
-  get isEnableSelectWork(): Signal<boolean> {
+  get isEnableSelectWork(): WritableSignal<boolean> {
     return this._isEnableSelectWork;
   }
-  get isVisibleDialog(): Signal<boolean> {
+  get isVisibleDialog(): WritableSignal<boolean> {
     return this._isVisibleDialog;
   }
-  get isEnablePlus(): Signal<boolean> {
+  get isEnablePlus(): WritableSignal<boolean> {
     return this._isEnablePlus;
   }
-  get isEnableMinus(): Signal<boolean> {
+  get isEnableMinus(): WritableSignal<boolean> {
     return this._isEnableMinus;
   }
-  get isEnableDecide(): Signal<boolean> {
+  get isEnableDecide(): WritableSignal<boolean> {
     return this._isEnableDecide;
   }
-  get isEnableBack(): Signal<boolean> {
+  get isEnableBack(): WritableSignal<boolean> {
     return this._isEnableBack;
   }
 }


### PR DESCRIPTION
## 概要
- globalStateおよびlocalState内のSignalをWritableSignalで定義
- Coding RulesにWritableSignal使用ルールを追加

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless` (Chromeが無いため失敗)


------
https://chatgpt.com/codex/tasks/task_e_689201fbf91c8331bed7e2398fecca70