### PR TITLE
ユニットテストの追加

### DIFF
--- a/demo/src/app/domain/service/impl/demo-service-impl-A.service.spec.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-A.service.spec.ts
@@ -1,0 +1,22 @@
+import { TestBed } from '@angular/core/testing';
+import { DemoServiceImplA } from './demo-service-impl-A.service';
+import { DemoState } from '../../state/global/demo-global.state';
+
+describe('DemoServiceImplA', () => {
+  let service: DemoServiceImplA;
+  let state: DemoState;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DemoServiceImplA);
+    state = TestBed.inject(DemoState);
+  });
+
+  it('should update progress on executeWork', () => {
+    service.selectUser('Taro');
+    service.selectWork('作業A');
+    service.executeWork(3);
+    expect(state.progress()).toBe(3);
+  });
+});

--- a/demo/src/app/domain/service/impl/demo-service-impl-B.service.spec.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-B.service.spec.ts
@@ -1,0 +1,22 @@
+import { TestBed } from '@angular/core/testing';
+import { DemoServiceImplB } from './demo-service-impl-B.service';
+import { DemoState } from '../../state/global/demo-global.state';
+
+describe('DemoServiceImplB', () => {
+  let service: DemoServiceImplB;
+  let state: DemoState;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DemoServiceImplB);
+    state = TestBed.inject(DemoState);
+  });
+
+  it('should update progress on executeWork', () => {
+    service.selectUser('Hanako');
+    service.selectWork('作業B');
+    service.executeWork(2);
+    expect(state.progress()).toBe(2);
+  });
+});

--- a/demo/src/app/domain/service/impl/demo-service-impl-C.service.spec.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-C.service.spec.ts
@@ -1,0 +1,28 @@
+import { TestBed } from '@angular/core/testing';
+import { DemoServiceImplC } from './demo-service-impl-C.service';
+import { DemoState } from '../../state/global/demo-global.state';
+import { DemoLocalStateC } from '../../state/local/demo-local-C.state';
+
+describe('DemoServiceImplC', () => {
+  let service: DemoServiceImplC;
+  let state: DemoState;
+  let local: DemoLocalStateC;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DemoServiceImplC);
+    state = TestBed.inject(DemoState);
+    local = TestBed.inject(DemoLocalStateC);
+  });
+
+  it('should toggle dialog and update progress', () => {
+    service.selectUser('Ichiro');
+    service.selectWork('作業C');
+    service.executeWork(2);
+    expect(local.isVisibleDialog()).toBeTrue();
+    service.executeWork(2);
+    expect(state.progress()).toBe(2);
+    expect(local.isVisibleDialog()).toBeFalse();
+  });
+});

--- a/demo/src/app/domain/service/impl/demo-service-impl-default.service.spec.ts
+++ b/demo/src/app/domain/service/impl/demo-service-impl-default.service.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed } from '@angular/core/testing';
+import { DemoServiceImplDefault } from './demo-service-impl-default.service';
+import { DemoState } from '../../state/global/demo-global.state';
+
+describe('DemoServiceImplDefault', () => {
+  let service: DemoServiceImplDefault;
+  let state: DemoState;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DemoServiceImplDefault);
+    state = TestBed.inject(DemoState);
+  });
+
+  it('should set work kind on selectWork', () => {
+    service.selectWork('作業B');
+    expect(state.workKind()).toBe('作業B');
+  });
+});

--- a/demo/src/app/domain/state/global/demo-global.state.spec.ts
+++ b/demo/src/app/domain/state/global/demo-global.state.spec.ts
@@ -1,0 +1,26 @@
+import { TestBed } from '@angular/core/testing';
+import { DemoState } from './demo-global.state';
+
+describe('DemoState', () => {
+  let state: DemoState;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    state = TestBed.inject(DemoState);
+  });
+
+  it('should update and reset progress', () => {
+    state.updateProgress(5);
+    expect(state.progress()).toBe(5);
+    state.completeWork();
+    expect(state.progress()).toBe(0);
+  });
+
+  it('should add and delete log', () => {
+    state.addLog('作業A', '実行', 'tester', 1);
+    expect(state.logs().length).toBe(1);
+    state.deleteLog(0);
+    expect(state.logs().length).toBe(0);
+  });
+});

--- a/demo/src/app/domain/state/local/demo-local-A.state.spec.ts
+++ b/demo/src/app/domain/state/local/demo-local-A.state.spec.ts
@@ -1,0 +1,21 @@
+import { TestBed } from '@angular/core/testing';
+import { DemoLocalStateA } from './demo-local-A.state';
+import { DemoState } from '../global/demo-global.state';
+
+describe('DemoLocalStateA', () => {
+  let globalState: DemoState;
+  let localState: DemoLocalStateA;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    globalState = TestBed.inject(DemoState);
+    localState = TestBed.inject(DemoLocalStateA);
+  });
+
+  it('should compute isEnableComplete based on progress', () => {
+    expect(localState.isEnableComplete()).toBeFalse();
+    globalState.updateProgress(10);
+    expect(localState.isEnableComplete()).toBeTrue();
+  });
+});

--- a/demo/src/app/domain/state/local/demo-local-B.state.spec.ts
+++ b/demo/src/app/domain/state/local/demo-local-B.state.spec.ts
@@ -1,0 +1,21 @@
+import { TestBed } from '@angular/core/testing';
+import { DemoLocalStateB } from './demo-local-B.state';
+import { DemoState } from '../global/demo-global.state';
+
+describe('DemoLocalStateB', () => {
+  let globalState: DemoState;
+  let localState: DemoLocalStateB;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    globalState = TestBed.inject(DemoState);
+    localState = TestBed.inject(DemoLocalStateB);
+  });
+
+  it('should compute isEnableComplete based on progress', () => {
+    expect(localState.isEnableComplete()).toBeFalse();
+    globalState.updateProgress(7);
+    expect(localState.isEnableComplete()).toBeTrue();
+  });
+});

--- a/demo/src/app/domain/state/local/demo-local-C.state.spec.ts
+++ b/demo/src/app/domain/state/local/demo-local-C.state.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed } from '@angular/core/testing';
+import { DemoLocalStateC } from './demo-local-C.state';
+import { DemoState } from '../global/demo-global.state';
+
+describe('DemoLocalStateC', () => {
+  let globalState: DemoState;
+  let localState: DemoLocalStateC;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    globalState = TestBed.inject(DemoState);
+    localState = TestBed.inject(DemoLocalStateC);
+  });
+
+  it('should compute isEnableComplete and toggle dialog', () => {
+    expect(localState.isEnableComplete()).toBeFalse();
+    globalState.updateProgress(10);
+    expect(localState.isEnableComplete()).toBeTrue();
+    expect(localState.isVisibleDialog()).toBeFalse();
+    localState.setDialogVisible(true);
+    expect(localState.isVisibleDialog()).toBeTrue();
+  });
+});

--- a/demo/src/app/domain/state/local/demo-local-default.state.spec.ts
+++ b/demo/src/app/domain/state/local/demo-local-default.state.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+import { DemoLocalStateDefault } from './demo-local-default.state';
+
+describe('DemoLocalStateDefault', () => {
+  let localState: DemoLocalStateDefault;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    localState = TestBed.inject(DemoLocalStateDefault);
+  });
+
+  it('should enable select user initially', () => {
+    expect(localState.isEnableSelectUser()).toBeTrue();
+  });
+});

--- a/demo/src/app/view/parts/demo-parts-center/demo-parts-center.spec.ts
+++ b/demo/src/app/view/parts/demo-parts-center/demo-parts-center.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DemoPartsCenter } from './demo-parts-center';
+
+describe('DemoPartsCenter', () => {
+  let component: DemoPartsCenter;
+  let fixture: ComponentFixture<DemoPartsCenter>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DemoPartsCenter]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DemoPartsCenter);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/demo/src/app/view/parts/demo-parts-dialog/demo-parts-dialog.spec.ts
+++ b/demo/src/app/view/parts/demo-parts-dialog/demo-parts-dialog.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DemoPartsDialog } from './demo-parts-dialog';
+
+describe('DemoPartsDialog', () => {
+  let component: DemoPartsDialog;
+  let fixture: ComponentFixture<DemoPartsDialog>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DemoPartsDialog]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DemoPartsDialog);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should change workCount via methods', () => {
+    component.onClickPlusBtn();
+    expect(component.workCount).toBe(2);
+    component.onClickMinusBtn();
+    expect(component.workCount).toBe(1);
+  });
+});

--- a/demo/src/app/view/parts/demo-parts-log/demo-parts-log.spec.ts
+++ b/demo/src/app/view/parts/demo-parts-log/demo-parts-log.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DemoPartsLog } from './demo-parts-log';
+
+describe('DemoPartsLog', () => {
+  let component: DemoPartsLog;
+  let fixture: ComponentFixture<DemoPartsLog>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DemoPartsLog]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DemoPartsLog);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit remove_log', () => {
+    const spy = jasmine.createSpy('remove');
+    component.remove_log.subscribe(spy);
+    component.remove(0);
+    expect(spy).toHaveBeenCalledWith(0);
+  });
+});

--- a/demo/src/app/view/parts/demo-parts-select/demo-parts-select.spec.ts
+++ b/demo/src/app/view/parts/demo-parts-select/demo-parts-select.spec.ts
@@ -1,0 +1,32 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DemoPartsSelect } from './demo-parts-select';
+
+describe('DemoPartsSelect', () => {
+  let component: DemoPartsSelect;
+  let fixture: ComponentFixture<DemoPartsSelect>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DemoPartsSelect]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DemoPartsSelect);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit select events', () => {
+    const userSpy = jasmine.createSpy('user');
+    const workSpy = jasmine.createSpy('work');
+    component.select_user.subscribe(userSpy);
+    component.select_work.subscribe(workSpy);
+    component.onSelectUser({ target: { value: 'A' } } as unknown as Event);
+    component.onSelectWork({ target: { value: 'W' } } as unknown as Event);
+    expect(userSpy).toHaveBeenCalledWith('A');
+    expect(workSpy).toHaveBeenCalledWith('W');
+  });
+});


### PR DESCRIPTION
## Summary
- DemoStateを含む各ステートクラスのシグナル動作を確認するテストを追加
- 各サービス実装に対する進捗更新やダイアログ制御のテストを作成
- Viewパーツコンポーネントの生成とイベント発火を検証するテストを追加

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` (ChromeHeadlessが見つからず失敗)


------
https://chatgpt.com/codex/tasks/task_e_68921a0edd708331983fcb1db47e70a5