### PR TITLE
fix: restore persisted state after reload

### DIFF
--- a/demo/src/app/domain/state/utils/persistent-state-auto.ts
+++ b/demo/src/app/domain/state/utils/persistent-state-auto.ts
@@ -2,21 +2,24 @@ import { WritableSignal, effect } from '@angular/core';
 
 export abstract class PersistentStateAuto {
   constructor(private readonly storageKey: string) {
-    const saved = localStorage.getItem(this.storageKey);
-    if (saved) {
-      try {
-        const parsed = JSON.parse(saved);
-        this.restoreSignals(parsed);
-      } catch (e) {
-        console.warn(`[${this.storageKey}] Failed to parse localStorage:`, e);
+    // サブクラスのフィールド初期化後に復元・監視を行う
+    queueMicrotask(() => {
+      const saved = localStorage.getItem(this.storageKey);
+      if (saved) {
+        try {
+          const parsed = JSON.parse(saved);
+          this.restoreSignals(parsed);
+        } catch (e) {
+          console.warn(`[${this.storageKey}] Failed to parse localStorage:`, e);
+        }
       }
-    }
 
-    // 自動保存
-    effect(() => this.autoSave());
+      // 自動保存
+      effect(() => this.autoSave());
 
-    // Signal変更のログ記録
-    this.setupLogging();
+      // Signal変更のログ記録
+      this.setupLogging();
+    });
   }
 
   // 保存対象の制限（null = 全Signal）


### PR DESCRIPTION
## 概要
- PersistentStateAutoの初期化順序を調整し、Signalの復元がサブクラスのフィールド初期化後に行われるよう修正

## テスト
- `npx ng test --watch=false --browsers=ChromeHeadless --no-progress` (Chrome未インストールのため失敗)

------
https://chatgpt.com/codex/tasks/task_e_68921e92eda8833196ba602bb4da03f5